### PR TITLE
Implemented remove functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 *.dSYM
 fhash_test
 .vscode/
+.vs/
 ref.out
+[Dd]ebug/
+[Rr]elease/
+x64/[Dd]ebug/
+x64/[Rr]elease/
+*.u2d
 
 # Prerequisites
 *.d

--- a/fhash.f90
+++ b/fhash.f90
@@ -398,9 +398,9 @@ module FHASH_MODULE_NAME
         this%node_ptr => this%fhash_ptr%buckets(this%bucket_id)
       else
         if (present(status)) status = -1
-#ifdef VALUE_POINTER
-        nullify(value)
-#endif
+#ifdef VALUE_TYPE_INIT
+        value VALUE_ASSIGNMENT VALUE_TYPE_INIT
+#endif        
         return
       endif
     enddo
@@ -416,9 +416,10 @@ end module
 
 #undef KEY_TYPE
 #undef VALUE_TYPE
+#undef VALUE_TYPE_INIT
+#undef VALUE_ASSIGNMENT
 #undef FHASH_TYPE_NAME
 #undef FHASH_TYPE_ITERATOR_NAME
-#undef VALUE_ASSIGNMENT
 #undef SHORTNAME
 #undef CONCAT
 #undef PASTE

--- a/fhash.f90
+++ b/fhash.f90
@@ -398,6 +398,9 @@ module FHASH_MODULE_NAME
         this%node_ptr => this%fhash_ptr%buckets(this%bucket_id)
       else
         if (present(status)) status = -1
+#ifdef VALUE_POINTER
+        nullify(value)
+#endif
         return
       endif
     enddo

--- a/fhash.f90
+++ b/fhash.f90
@@ -106,6 +106,15 @@ module FHASH_MODULE_NAME
       ! Otherwise, fail and return 0.
       procedure :: node_get
 
+      ! If kv is not allocated, fail and return
+      ! If key is present and node is first in bucket, set first node in bucket to 
+      !   the next node of first. Return success
+      ! If key is present and the node is another member of the linked list, link the 
+      !   previous node's next node to this node's next node, deallocate this node, 
+      !   return success
+      ! Otherwise, fail and return 0
+      procedure :: node_remove
+      
       ! Deallocate kv is allocated.
       ! Call the clear method of the next node if the next pointer associated.
       ! Deallocate and nullify the next pointer.
@@ -140,6 +149,9 @@ module FHASH_MODULE_NAME
 
       ! Get the value at the given key.
       procedure, public :: get
+
+      ! Remove the value with the given key.
+      procedure, public :: remove
 
       ! Clear all the allocated memory (must be called to prevent memory leak).
       procedure, public :: clear
@@ -280,6 +292,61 @@ module FHASH_MODULE_NAME
       call this%next%node_get(key, value, success)
     else
       if (present(success)) success = .false.
+    endif
+  end subroutine
+  
+  subroutine remove(this, key, success)
+    class(FHASH_TYPE_NAME), intent(inout) :: this
+    KEY_TYPE, intent(in) :: key
+    logical, optional, intent(out) :: success
+
+    integer :: bucket_id
+    type(node_type)  ::  first
+    logical ::  locSuccess
+    
+    bucket_id = modulo(hash_value(key), this%n_buckets) + 1
+    first = this%buckets(bucket_id)
+
+    if (allocated(first%kv)) then
+      if (first%kv%key == key) then
+        if (associated(first%next)) then
+          this%buckets(bucket_id)%kv%key =  this%buckets(bucket_id)%next%kv%key
+          this%buckets(bucket_id)%kv%value VALUE_ASSIGNMENT this%buckets(bucket_id)%next%kv%value
+          deallocate(first%next%kv)
+          this%buckets(bucket_id)%next => this%buckets(bucket_id)%next%next 
+        else
+          deallocate(this%buckets(bucket_id)%kv)
+        endif
+        locSuccess = .true.
+      else
+        call node_remove(first%next, key, locSuccess, first)
+      end if
+    else
+      locSuccess = .false.      
+    endif
+    
+    if (locSuccess) this%n_keys = this%n_keys - 1
+    if (present(success)) success = locSuccess
+    
+  end subroutine
+
+  recursive subroutine node_remove(this, key, success, last)
+    class(node_type), intent(inout) :: this, last
+    KEY_TYPE, intent(in) :: key
+    logical, intent(out) :: success
+    
+    if (.not. allocated(this%kv)) then
+      ! Not found. (Initial node in the bucket not set)
+      success = .false.
+    else if (this%kv%key == key) then
+      last%next => this%next
+      nullify(this%next)
+      deallocate(this%kv)
+      success = .true.
+    else if (associated(this%next)) then
+      call this%next%node_remove(key, success, this)
+    else
+      success = .false.
     endif
   end subroutine
 

--- a/fhash.sln
+++ b/fhash.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "fhash", "fhash.vfproj", "{8125E353-C1AE-435F-9F4F-C397B227C2BD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Debug|x64.ActiveCfg = Debug|x64
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Debug|x64.Build.0 = Debug|x64
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Debug|x86.ActiveCfg = Debug|Win32
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Debug|x86.Build.0 = Debug|Win32
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Release|x64.ActiveCfg = Release|x64
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Release|x64.Build.0 = Release|x64
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Release|x86.ActiveCfg = Release|Win32
+		{8125E353-C1AE-435F-9F4F-C397B227C2BD}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {682F1E51-0A4D-4872-AD7E-B2180A80F0A8}
+	EndGlobalSection
+EndGlobal

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -67,10 +67,11 @@ module ints_module
 end module ints_module
 
 ! Define the macros needed by fhash and include fhash.f90
-#define KEY_TYPE type(ints_type)
-#define VALUE_TYPE real(real64)
 #define KEY_USE use ints_module
+#define KEY_TYPE type(ints_type)
 #define VALUE_USE use, intrinsic :: iso_fortran_env
+#define VALUE_TYPE real(real64)
+#define VALUE_TYPE_INIT 0.0
 #define SHORTNAME ints_double
 #include "fhash.f90"
 
@@ -92,12 +93,16 @@ module int_module
 end module
 
 ! Define the macros needed by fhash and include fhash.f90
-#define KEY_TYPE integer
-#define VALUE_TYPE type(ints_type), pointer
 #define KEY_USE use int_module
+#define KEY_TYPE integer
 #define VALUE_USE use ints_module
+#define VALUE_TYPE type(ints_type), pointer
+!#define VALUE_TYPE_INIT null()
 #define SHORTNAME int_ints_ptr
 #ifndef __GFORTRAN__
 #define VALUE_POINTER
+#endif
+#ifdef VALUE_TYPE_INIT
+#define CHECK_ITERATOR_VALUE
 #endif
 #include "fhash.f90"

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -162,6 +162,8 @@ program fhash_test
     
     if (associated(pValue)) stop 'expect .not. associated(pValue)'
     
+    call h%clear()
+    
     deallocate(pValues)
     
   end subroutine  
@@ -210,6 +212,7 @@ program fhash_test
     ! Check end of hash table.
     call it%next(key, value, status)
     if (status /= -1) stop 'expect to return -1'
+    
     call h%clear()
   end subroutine
 

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -159,9 +159,11 @@ program fhash_test
       if (mod(key, 5) .eq. 1) stop 'expect not to get deleted keys'
       if (mod(key, 5) .eq. 4) stop 'expect not to get deleted keys'
     end do
-    
+#ifdef CHECK_ITERATOR_VALUE
+#undef CHECK_ITERATOR_VALUE
     if (associated(pValue)) stop 'expect .not. associated(pValue)'
-    
+#endif
+
     call h%clear()
     
     deallocate(pValues)


### PR DESCRIPTION
The possiblilty to `remove` items from the FHASH store is missing, this PR adds it. I have tried to closely follow the semantics of the existing functionality.

A unit test for `remove` is included.

Additionally `FHASH_TYPE_ITERATOR__` can be configured to initialize the return value when the returned `status .ne. 0`. This is done by setting the [`VALUE_TYPE_INIT`](https://github.com/jl2922/fhash/pull/2/files#diff-8681f799e5110291675724f24346bf44R74) macro to some value.