### PR TITLE
some cleunup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ FFLAGS_BASIC += -Wunused-parameter
 FFLAGS_BASIC += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
 FFLAGS_BASIC += -Wno-unused-function
 FFLAGS_BASIC += -Wno-conversion
+FFLAGS_BASIC += -Wno-implicit-interface -Wno-strict-overflow # implicit interface is necessary for calling qsort with general types. Conversions from/to C ints are harmless.
 
 FFLAGS_DEVEL = -O0 -fcheck=all -fbounds-check -Warray-bounds -Wstrict-overflow=5 -Wunderflow -ffpe-trap=invalid,zero,overflow
 # FFLAGS_DEVEL += -ftrapv
@@ -19,7 +20,7 @@ FFLAGS_RELEASE = -O3
 # FFLAGS_BASIC += -Wdo-subscript  -std=f2018  -Wfrontend-loop-interchange
 # FFLAGS_DEVEL += -fsanitize-address-use-after-scope
 
-FFLAGS = $(FFLAGS_BASIC) $(FFLAGS_DEVEL)
+FFLAGS = $(FFLAGS_DEVEL) $(FFLAGS_BASIC)
 
 .PHONY: all test clean ref
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ FFLAGS_RELEASE = -O3
 # FFLAGS_BASIC += -Wdo-subscript  -std=f2018  -Wfrontend-loop-interchange
 # FFLAGS_DEVEL += -fsanitize-address-use-after-scope
 
+# FC = ifort
+# FFLAGS_BASIC = -g -traceback -cpp
+# FFLAGS_DEVEL = -O0
+
 FFLAGS = $(FFLAGS_DEVEL) $(FFLAGS_BASIC)
 
 .PHONY: all test clean ref

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,25 @@
 CPPC = g++
 FC := gfortran
-FFLAGS = -g -fbacktrace -std=f2018 -pedantic -Wall -Wextra -cpp
-FFLAGS += -Werror -Werror=shadow -Werror=intrinsic-shadow -Wuninitialized
-FFLAGS += -Wunreachable-code
-FFLAGS += -Waliasing -Wampersand -Wc-binding-type -Wcharacter-truncation
-FFLAGS += -Wdo-subscript -Wfunction-elimination -Wimplicit-interface -Wimplicit-procedure -Wintrinsic-shadow -Wintrinsics-std -Wline-truncation -Wno-tabs
-FFLAGS += -Wreal-q-constant -Wsurprising
-FFLAGS += -Wunused-parameter -Wfrontend-loop-interchange
-FFLAGS += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
-FFLAGS += -Wno-unused-function
-FFLAGS += -Wno-conversion
+FFLAGS_BASIC = -g -fbacktrace -std=f2008 -pedantic -Wall -Wextra -cpp
+FFLAGS_BASIC += -Werror -Werror=shadow -Werror=intrinsic-shadow -Wuninitialized
+FFLAGS_BASIC += -Wunreachable-code -Wconversion
+FFLAGS_BASIC += -Waliasing -Wampersand -Wc-binding-type -Wcharacter-truncation
+FFLAGS_BASIC += -Wfunction-elimination -Wimplicit-interface -Wimplicit-procedure -Wintrinsic-shadow -Wintrinsics-std -Wline-truncation -Wno-tabs
+FFLAGS_BASIC += -Wreal-q-constant -Wsurprising
+FFLAGS_BASIC += -Wunused-parameter
+FFLAGS_BASIC += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
+FFLAGS_BASIC += -Wno-unused-function
+FFLAGS_BASIC += -Wno-conversion
 
-FFLAGS_DEVEL = -O0 -fcheck=all -fbounds-check -Warray-bounds -Wstrict-overflow=5 -Wunderflow -fsanitize-address-use-after-scope -ffpe-trap=invalid,zero,overflow
+FFLAGS_DEVEL = -O0 -fcheck=all -fbounds-check -Warray-bounds -Wstrict-overflow=5 -Wunderflow -ffpe-trap=invalid,zero,overflow
 # FFLAGS_DEVEL += -ftrapv
 FFLAGS_RELEASE = -O3
-FFLAGS += $(FFLAGS_RELEASE)
+
+# not yet in gfortran 4.8.5:
+# FFLAGS_BASIC += -Wdo-subscript  -std=f2018  -Wfrontend-loop-interchange
+# FFLAGS_DEVEL += -fsanitize-address-use-after-scope
+
+FFLAGS = $(FFLAGS_BASIC) $(FFLAGS_DEVEL)
 
 .PHONY: all test clean ref
 
@@ -25,9 +30,9 @@ test: fhash_modules fhash_test.f90
         &&   ./fhash_test.out
 
 benchmark: fhash_modules.f90 benchmark.f90
-	$(FC) -cpp -O3 benchmark.f90 -o fhash_benchmark.out  && \
+	$(FC) $(FFLAGS_BASIC) $(FFLAGS_RELEASE) benchmark.f90 -o fhash_benchmark.out  && \
     $(CPPC) -std=c++11 -O3  benchmark.cc  -o stl_benchmark.out && \
-	./stl_benchmark.out  &&  ./fhash_benchmark.out
+	./fhash_benchmark.out  &&  ./stl_benchmark.out
 
 ref: benchmark.cc
 	g++ -O3 -std=c++14 benchmark.cc -o ref.out && ./ref.out

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test: fhash_modules fhash_test.f90
 benchmark: fhash_benchmark.out stl_benchmark.out
 	./fhash_benchmark.out  &&  ./stl_benchmark.out
 
-fhash_benchmark.out: fhash_modules.f90 benchmark.f90
+fhash_benchmark.out: fhash.f90 fhash_modules.f90 benchmark.f90
 	$(FC) $(FFLAGS_BASIC) $(FFLAGS_RELEASE) fhash_modules.f90 benchmark.f90 -o fhash_benchmark.out
 
 stl_benchmark.out: benchmark.cc

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,26 @@
 FC := gfortran
-FFLAGS := -O3 -g -fbounds-check -Wall -Wextra -cpp -Wno-unused-dummy-argument
+FFLAGS = -g -fbacktrace -std=f2018 -pedantic -Wall -Wextra -cpp -Wno-unused-dummy-argument
+FFLAGS += -Werror -Werror=shadow -Werror=intrinsic-shadow -Wuninitialized
+FFLAGS += -Wunreachable-code -Wconversion
+FFLAGS += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
+FFLAGS += -Waliasing -Wampersand -Wc-binding-type -Wcharacter-truncation -Wconversion
+FFLAGS += -Wno-error=unused-function
+FFLAGS += -Wdo-subscript -Wfunction-elimination -Wimplicit-interface -Wimplicit-procedure -Wintrinsic-shadow -Wintrinsics-std -Wline-truncation -Wno-tabs
+FFLAGS += -Wreal-q-constant -Wsurprising
+FFLAGS += -Wunused-parameter -Wfrontend-loop-interchange
+
+FFLAGS_DEVEL = -O0 -fcheck=all -fbounds-check -Warray-bounds -Wstrict-overflow=5 -Wunderflow -fsanitize-address-use-after-scope -ffpe-trap=invalid,zero,overflow
+# FFLAGS_DEVEL += -ftrapv
+FFLAGS_RELEASE = -O3
+FFLAGS += $(FFLAGS_RELEASE)
 
 .PHONY: all test clean ref
 
 all: test
 
 test: fhash_modules fhash_test.f90
-	$(FC) $(FFLAGS) fhash_modules.f90 fhash_test.f90 -o fhash_test.out && ./fhash_test.out
+	$(FC) $(FFLAGS) fhash_modules.f90 fhash_test.f90 -o fhash_test.out  \
+        &&   ./fhash_test.out
 
 ref: benchmark.cc
 	g++ -O3 -std=c++14 benchmark.cc -o ref.out && ./ref.out

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,15 @@ FFLAGS_RELEASE = -O3
 # FFLAGS_BASIC += -Wdo-subscript  -std=f2018  -Wfrontend-loop-interchange
 # FFLAGS_DEVEL += -fsanitize-address-use-after-scope
 
+# CPPC = icpc
 # FC = ifort
 # FFLAGS_BASIC = -g -traceback -cpp
 # FFLAGS_DEVEL = -O0
+# FFLAGS_RELEASE = -Ofast
 
 FFLAGS = $(FFLAGS_DEVEL) $(FFLAGS_BASIC)
 
-.PHONY: all test clean ref
+.PHONY: all test clean
 
 all: test
 
@@ -34,13 +36,14 @@ test: fhash_modules fhash_test.f90
 	$(FC) $(FFLAGS) fhash_modules.f90 fhash_test.f90 -o fhash_test.out  \
         &&   ./fhash_test.out
 
-benchmark: fhash_modules.f90 benchmark.f90
-	$(FC) $(FFLAGS_BASIC) $(FFLAGS_RELEASE) benchmark.f90 -o fhash_benchmark.out  && \
-    $(CPPC) -std=c++11 -O3  benchmark.cc  -o stl_benchmark.out && \
+benchmark: fhash_benchmark.out stl_benchmark.out
 	./fhash_benchmark.out  &&  ./stl_benchmark.out
 
-ref: benchmark.cc
-	g++ -O3 -std=c++14 benchmark.cc -o ref.out && ./ref.out
+fhash_benchmark.out: fhash_modules.f90 benchmark.f90
+	$(FC) $(FFLAGS_BASIC) $(FFLAGS_RELEASE) fhash_modules.f90 benchmark.f90 -o fhash_benchmark.out
+
+stl_benchmark.out: benchmark.cc
+	 $(CPPC) -std=c++11 -O3 $< -o $@
 
 clean:
 	rm -rf *.mod *.o

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CPPC = g++
 FC := gfortran
 FFLAGS = -g -fbacktrace -std=f2018 -pedantic -Wall -Wextra -cpp
 FFLAGS += -Werror -Werror=shadow -Werror=intrinsic-shadow -Wuninitialized
@@ -22,6 +23,11 @@ all: test
 test: fhash_modules fhash_test.f90
 	$(FC) $(FFLAGS) fhash_modules.f90 fhash_test.f90 -o fhash_test.out  \
         &&   ./fhash_test.out
+
+benchmark: fhash_modules.f90 benchmark.f90
+	$(FC) -cpp -O3 benchmark.f90 -o fhash_benchmark.out  && \
+    $(CPPC) -std=c++11 -O3  benchmark.cc  -o stl_benchmark.out && \
+	./stl_benchmark.out  &&  ./fhash_benchmark.out
 
 ref: benchmark.cc
 	g++ -O3 -std=c++14 benchmark.cc -o ref.out && ./ref.out

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 FC := gfortran
-FFLAGS = -g -fbacktrace -std=f2018 -pedantic -Wall -Wextra -cpp -Wno-unused-dummy-argument
+FFLAGS = -g -fbacktrace -std=f2018 -pedantic -Wall -Wextra -cpp
 FFLAGS += -Werror -Werror=shadow -Werror=intrinsic-shadow -Wuninitialized
-FFLAGS += -Wunreachable-code -Wconversion
-FFLAGS += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
-FFLAGS += -Waliasing -Wampersand -Wc-binding-type -Wcharacter-truncation -Wconversion
-FFLAGS += -Wno-unused-function
+FFLAGS += -Wunreachable-code
+FFLAGS += -Waliasing -Wampersand -Wc-binding-type -Wcharacter-truncation
 FFLAGS += -Wdo-subscript -Wfunction-elimination -Wimplicit-interface -Wimplicit-procedure -Wintrinsic-shadow -Wintrinsics-std -Wline-truncation -Wno-tabs
 FFLAGS += -Wreal-q-constant -Wsurprising
 FFLAGS += -Wunused-parameter -Wfrontend-loop-interchange
+FFLAGS += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
+FFLAGS += -Wno-unused-function
+FFLAGS += -Wno-conversion
 
 FFLAGS_DEVEL = -O0 -fcheck=all -fbounds-check -Warray-bounds -Wstrict-overflow=5 -Wunderflow -fsanitize-address-use-after-scope -ffpe-trap=invalid,zero,overflow
 # FFLAGS_DEVEL += -ftrapv

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ FFLAGS += -Werror -Werror=shadow -Werror=intrinsic-shadow -Wuninitialized
 FFLAGS += -Wunreachable-code -Wconversion
 FFLAGS += -Wno-maybe-uninitialized -Wno-unused-dummy-argument -Wno-error=return-type
 FFLAGS += -Waliasing -Wampersand -Wc-binding-type -Wcharacter-truncation -Wconversion
-FFLAGS += -Wno-error=unused-function
+FFLAGS += -Wno-unused-function
 FFLAGS += -Wdo-subscript -Wfunction-elimination -Wimplicit-interface -Wimplicit-procedure -Wintrinsic-shadow -Wintrinsics-std -Wline-truncation -Wno-tabs
 FFLAGS += -Wreal-q-constant -Wsurprising
 FFLAGS += -Wunused-parameter -Wfrontend-loop-interchange

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 Fast hash map implementation in fortran
 
 ## Description
-Implemention of the GCC hashmap structure in Fortran. With the usage of macros, it can support any types of keys and values, as long as you implement (or the compiler provides) the corresponding `KEYS_EQUAL_FUNC` (defaults to `==`), assignment operator(=) and the hash_value interface of the key type and the assignment operator of the value type.
+Implemention of the GCC hashmap structure in Fortran. It supports any types of keys and values, as long as you set the following macros:
+
+* `KEY_TYPE` and `VALUE_TYPE` with corresponding use statements `KEY_USE` and `VALUE_USE`,
+
+and, optionally,
+
+* `KEYS_EQUAL_FUNC`: the comparison operator for the keys (defaults to either `a == b` or `all(a == b)`, depending on whether `KEY_IS_ARRAY` is defined.);
+
+* `HASH_FUNC`, which takes a key and returns a hash integer. There are defaults for integers and integer arrays;
+
+* `VALUE_POINTER`: when defined the values are assumed to be pointers.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Implemention of the GCC hashmap structure in Fortran. It supports any types of k
 
 and, optionally,
 
-* `KEYS_EQUAL_FUNC`: the comparison operator for the keys (defaults to either `a == b` or `all(a == b)`, depending on whether `KEY_IS_ARRAY` is defined.);
+* `KEYS_EQUAL_FUNC`: the comparison operator for the keys (defaults to either `a == b` or `all(a == b)`, depending on whether the key is a scalar;
 
 * `HASH_FUNC`, which takes a key and returns a hash integer. There are defaults for integers and integer arrays;
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Fast hash map implementation in fortran
 
 ## Description
-Implemention of the GCC hashmap structure in Fortran. With the usage of macros, it can support any types of keys and values, as long as you implement (or the compiler provides) the corresponding equal operator(==), assignment operator(=) and the hash_value interface of the key type and the assignment operator of the value type.
+Implemention of the GCC hashmap structure in Fortran. With the usage of macros, it can support any types of keys and values, as long as you implement (or the compiler provides) the corresponding `KEYS_EQUAL_FUNC` (defaults to `==`), assignment operator(=) and the hash_value interface of the key type and the assignment operator of the value type.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -18,40 +18,25 @@ and, optionally,
 
 ## Benchmarks
 
-Here are the benchmarks between my Fortran implementation and GCC 4.8 standard library:
+For
 
-For 14 integer array as the key, double precision floating point as the value, 10M entries:
+* key: integer array of size 2;
 
-Fortran hash:
+* value: double precision (64-bit) floating point;
 
-> Insert: 1.80 s
->
-> Clean: 1.70 s
->
-> 1.59 GB
+* 10M entries,
 
-GCC unordered_map:
+on
 
-> Insert: 2.02 s
-> 
-> Clean: 0.61 s
-> 
-> 1.38 GB
+* Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz;
 
-For 2 integer array as the key, double precision floating point as the value, 20M entries:
+* Ubuntu 20.04.3 LTS,
 
-Fortran hash:
+I got
 
-> Insert: 2.66 s
-> 
-> Clean: 2.54 s
-> 
-> 2.57 GB
-
-GCC unordered_map:
-
-> Insert: 3.60 s
-> 
-> Clean: 1.07 s
-> 
-> 2.16 GB
+|           |               | ifort 2021 | gfortran 9 |
+|-----------|---------------|------------|------------|
+| *insert*  | **fhash**     | 2.99       | 2.38       |
+|           | **C++ (STL)** | 2.80       | 2.69       |
+| *clear*   | **fhash**     | 1.24       | 0.391      |
+|           | **C++ (STL)** | 0.37       | 0.328      |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Fast hash map implementation in fortran
 ## Description
 Implemention of the GCC hashmap structure in Fortran. It supports any types of keys and values, as long as you set the following macros:
 
+* `FHASH_NAME`;
+
 * `KEY_TYPE` and `VALUE_TYPE` with corresponding use statements `KEY_USE` and `VALUE_USE`,
 
 and, optionally,

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -4,7 +4,7 @@
 #include <unordered_map>
 
 constexpr int N_INTS = 2;
-constexpr int N_KEYS = 10000000;
+constexpr int N_KEYS = 1e7;
 
 int main() {
   std::cout << "Start C++ STL benchmark:\n";
@@ -12,8 +12,9 @@ int main() {
   typedef std::array<int, N_INTS> KeyType;
   std::unordered_map<std::array<int, N_INTS>, double, boost::hash<KeyType>> h;
 
-  const double t0 = std::clock();
   h.reserve(N_KEYS * 2);
+  const double t0 = std::clock();
+
   KeyType key;
   for (int i = 1; i <= N_KEYS; i++) {
     for (int j = 1; j <= N_INTS; j++) {
@@ -21,13 +22,25 @@ int main() {
     }
     h[key] = i * 0.5;
   }
-
   const double t1 = std::clock();
-  h.clear();
 
+  double val;
+  for (int i = 1; i <= N_KEYS; i++) {
+    for (int j = 1; j <= N_INTS; j++) {
+      key[j - 1] = i + j;
+    }
+    val = h[key];
+  }
   const double t2 = std::clock();
-  std::cout << "Time to assemble: " << (t1 - t0) / CLOCKS_PER_SEC << "\n";
-  std::cout << "Time to clear: " << (t2 - t1) / CLOCKS_PER_SEC << "\n";
+
+  h.clear();
+  const double t3 = std::clock();
+
+  std::cout << "Time to assemble / get / clear:"
+      << "       " << (t1 - t0) / CLOCKS_PER_SEC
+      << "       " << (t2 - t1) / CLOCKS_PER_SEC
+      << "       " << (t3 - t2) / CLOCKS_PER_SEC
+      << "\n";
 
   return 0;
 }

--- a/benchmark.cc
+++ b/benchmark.cc
@@ -1,38 +1,33 @@
 #include <boost/functional/hash.hpp>
-#include <cstdio>
-#include <cstdlib>
+#include <iostream>
 #include <ctime>
 #include <unordered_map>
-#include <vector>
 
-#define N_INTS 2
-#define N_KEYS 20000000
+constexpr int N_INTS = 2;
+constexpr int N_KEYS = 10000000;
 
-void benchmark() {
-  typedef std::vector<int> KeyType;
-  const std::clock_t start = std::clock();
-  std::unordered_map<KeyType, double, boost::hash<KeyType>> h;
+int main() {
+  std::cout << "Start C++ STL benchmark:\n";
+
+  typedef std::array<int, N_INTS> KeyType;
+  std::unordered_map<std::array<int, N_INTS>, double, boost::hash<KeyType>> h;
+
+  const double t0 = std::clock();
   h.reserve(N_KEYS * 2);
-  KeyType key(N_INTS);
+  KeyType key;
   for (int i = 1; i <= N_KEYS; i++) {
     for (int j = 1; j <= N_INTS; j++) {
       key[j - 1] = i + j;
     }
     h[key] = i * 0.5;
   }
-  const std::clock_t finish = std::clock();
-  printf("Time insert: %.3g s\n",
-         static_cast<double>(finish - start) / CLOCKS_PER_SEC);
-  h.clear();
-}
 
-int main() {
-  typedef std::vector<int> KeyType;
-  const std::clock_t start = std::clock();
-  benchmark();
-  const std::clock_t finish = std::clock();
-  printf("Time finish: %.3g s\n",
-         static_cast<double>(finish - start) / CLOCKS_PER_SEC);
+  const double t1 = std::clock();
+  h.clear();
+
+  const double t2 = std::clock();
+  std::cout << "Time to assemble: " << (t1 - t0) / CLOCKS_PER_SEC << "\n";
+  std::cout << "Time to clear: " << (t2 - t1) / CLOCKS_PER_SEC << "\n";
 
   return 0;
 }

--- a/benchmark.f90
+++ b/benchmark.f90
@@ -4,7 +4,6 @@
 #define FHASH_TYPE_NAME int_intsptr_fhash_type
 #define FHASH_TYPE_ITERATOR_NAME int_intsptr_fhash_iter_type
 #define KEY_TYPE integer, dimension(KEY_ARRAY_SIZE)
-#define KEY_IS_ARRAY
 #define VALUE_TYPE real(real64)
 #define VALUE_USE use, intrinsic :: iso_fortran_env, only: real64
 ! #define VALUE_TYPE_INIT null()

--- a/benchmark.f90
+++ b/benchmark.f90
@@ -1,0 +1,51 @@
+#define KEY_ARRAY_SIZE 2
+
+#define FHASH_MODULE_NAME int_intsptr_fhash_mod
+#define FHASH_TYPE_NAME int_intsptr_fhash_type
+#define FHASH_TYPE_ITERATOR_NAME int_intsptr_fhash_iter_type
+#define KEY_TYPE integer, dimension(KEY_ARRAY_SIZE)
+#define KEY_IS_ARRAY
+#define VALUE_TYPE real(real64)
+#define VALUE_USE use, intrinsic :: iso_fortran_env, only: real64
+! #define VALUE_TYPE_INIT null()
+! #define VALUE_POINTER
+#include "fhash.f90"
+
+program test_benchmark
+  implicit none
+  
+  real :: start, finish
+
+  print *, 'Start benchmark:'
+  call cpu_time(start)
+  call benchmark(n_ints = KEY_ARRAY_SIZE, n_keys=10000000)
+  call cpu_time(finish)
+  print '("Time finish = ", G0.3," seconds.")', finish - start
+  
+  contains
+  subroutine benchmark(n_ints, n_keys)
+    use int_intsptr_fhash_mod
+    use, intrinsic :: iso_fortran_env, only: real64
+
+    integer, intent(in) :: n_ints, n_keys
+
+    type(int_intsptr_fhash_type) :: h
+    integer :: key(n_ints)
+    real :: start, finish
+    integer :: i, j
+
+    print '("n_ints: ", I0, ", n_keys: ", I0)', n_ints, n_keys
+
+    call cpu_time(start)
+    call h%reserve(n_keys * 2)
+    do i = 1, n_keys
+      do j = 1, n_ints
+        key(j) = i + j
+      enddo
+      call h%set(key, (i + j) * 0.5_real64)
+    enddo
+    call cpu_time(finish)
+    print '("Time insert = ", G0.3," seconds.")', finish - start
+    call h%clear()
+  end subroutine
+end program

--- a/benchmark.f90
+++ b/benchmark.f90
@@ -14,38 +14,38 @@
 program test_benchmark
   implicit none
   
-  real :: start, finish
-
-  print *, 'Start benchmark:'
-  call cpu_time(start)
-  call benchmark(n_ints = KEY_ARRAY_SIZE, n_keys=10000000)
-  call cpu_time(finish)
-  print '("Time finish = ", G0.3," seconds.")', finish - start
+  call benchmark(n_ints=KEY_ARRAY_SIZE, n_keys=10000000)
   
-  contains
+contains
   subroutine benchmark(n_ints, n_keys)
     use int_intsptr_fhash_mod
-    use, intrinsic :: iso_fortran_env, only: real64
 
     integer, intent(in) :: n_ints, n_keys
 
     type(int_intsptr_fhash_type) :: h
     integer :: key(n_ints)
-    real :: start, finish
     integer :: i, j
+    real :: t0, t1, t2
 
-    print '("n_ints: ", I0, ", n_keys: ", I0)', n_ints, n_keys
+    write(*,'(a)') "Start fhash benchmark:"
 
-    call cpu_time(start)
+    write(*,'("n_ints: ", I0, ", n_keys: ", I0)') n_ints, n_keys
+
+    call cpu_time(t0)
     call h%reserve(n_keys * 2)
     do i = 1, n_keys
       do j = 1, n_ints
         key(j) = i + j
       enddo
-      call h%set(key, (i + j) * 0.5_real64)
+      call h%set(key, i * 0.5d0)
     enddo
-    call cpu_time(finish)
-    print '("Time insert = ", G0.3," seconds.")', finish - start
+
+    call cpu_time(t1)
+
     call h%clear()
+    call cpu_time(t2)
+
+    write(*,'(a,g0.3)') "Time to assemble: ", t1 - t0
+    write(*,'(a,g0.3)') "Time to clear: ", t2 - t1
   end subroutine
 end program

--- a/benchmark.f90
+++ b/benchmark.f90
@@ -9,38 +9,47 @@
 program test_benchmark
   implicit none
   
-  call benchmark(n_ints=KEY_ARRAY_SIZE, n_keys=10000000)
+  call benchmark(n_ints=KEY_ARRAY_SIZE, n_keys=10**7)
   
 contains
   subroutine benchmark(n_ints, n_keys)
     use int2real_mod
+    use iso_fortran_env, only: real64
 
     integer, intent(in) :: n_ints, n_keys
 
     type(int2real_t) :: h
     integer :: key(n_ints)
     integer :: i, j
-    real :: t0, t1, t2
+    real :: t0, t1, t2, t3
+    real(real64), pointer :: val
 
     write(*,'(a)') "Start fhash benchmark:"
 
     write(*,'("n_ints: ", I0, ", n_keys: ", I0)') n_ints, n_keys
 
-    call cpu_time(t0)
     call h%reserve(n_keys * 2)
+    call cpu_time(t0)
+
     do i = 1, n_keys
       do j = 1, n_ints
         key(j) = i + j
       enddo
       call h%set(key, i * 0.5d0)
     enddo
-
     call cpu_time(t1)
 
-    call h%clear()
+    do i = 1, n_keys
+      do j = 1, n_ints
+        key(j) = i + j
+      enddo
+      val => h%get_ptr(key) ! , autoval=3.0_real64)
+    enddo
     call cpu_time(t2)
 
-    write(*,'(a,g0.3)') "Time to assemble: ", t1 - t0
-    write(*,'(a,g0.3)') "Time to clear: ", t2 - t1
+    call h%clear()
+    call cpu_time(t3)
+
+    write(*,'(a,3(g15.3))') "Time to assemble/ get / clear: ", t1 - t0, t2 - t1, t3 - t2
   end subroutine
 end program

--- a/benchmark.f90
+++ b/benchmark.f90
@@ -1,13 +1,9 @@
 #define KEY_ARRAY_SIZE 2
 
-#define FHASH_MODULE_NAME int_intsptr_fhash_mod
-#define FHASH_TYPE_NAME int_intsptr_fhash_type
-#define FHASH_TYPE_ITERATOR_NAME int_intsptr_fhash_iter_type
+#define SHORTNAME int2real
 #define KEY_TYPE integer, dimension(KEY_ARRAY_SIZE)
 #define VALUE_TYPE real(real64)
 #define VALUE_USE use, intrinsic :: iso_fortran_env, only: real64
-! #define VALUE_TYPE_INIT null()
-! #define VALUE_POINTER
 #include "fhash.f90"
 
 program test_benchmark
@@ -17,11 +13,11 @@ program test_benchmark
   
 contains
   subroutine benchmark(n_ints, n_keys)
-    use int_intsptr_fhash_mod
+    use fhash_module__int2real
 
     integer, intent(in) :: n_ints, n_keys
 
-    type(int_intsptr_fhash_type) :: h
+    type(fhash_type__int2real) :: h
     integer :: key(n_ints)
     integer :: i, j
     real :: t0, t1, t2

--- a/benchmark.f90
+++ b/benchmark.f90
@@ -1,6 +1,6 @@
 #define KEY_ARRAY_SIZE 2
 
-#define SHORTNAME int2real
+#define FHASH_NAME int2real
 #define KEY_TYPE integer, dimension(KEY_ARRAY_SIZE)
 #define VALUE_TYPE real(real64)
 #define VALUE_USE use, intrinsic :: iso_fortran_env, only: real64
@@ -13,11 +13,11 @@ program test_benchmark
   
 contains
   subroutine benchmark(n_ints, n_keys)
-    use fhash_module__int2real
+    use int2real_mod
 
     integer, intent(in) :: n_ints, n_keys
 
-    type(fhash_type__int2real) :: h
+    type(int2real_t) :: h
     integer :: key(n_ints)
     integer :: i, j
     real :: t0, t1, t2

--- a/fhash.f90
+++ b/fhash.f90
@@ -206,24 +206,23 @@ module FHASH_MODULE_NAME
   subroutine reserve(this, n_buckets)
     class(FHASH_TYPE_NAME), intent(inout) :: this
     integer, intent(in) :: n_buckets
-    integer, dimension(29) :: sizes
+
     integer :: i
+    integer, parameter :: sizes(*) = [5, 11, 23, 47, 97, 199, 409, 823, 1741, 3469, 6949, 14033, &
+    & 28411, 57557, 116731, 236897, 480881, 976369,1982627, 4026031, &
+    & 8175383, 16601593, 33712729, 68460391, 139022417, 282312799, &
+    & 573292817, 1164186217, 2147483647]
 
     if (this%key_count() > 0) stop 'Cannot reserve when fhash is not empty.'
+    if (n_buckets > sizes(size(sizes))) stop "Did not expect to need this many buckets."
 
-    sizes = (/5, 11, 23, 47, 97, 199, 409, 823, 1741, 3469, 6949, 14033, &
-      & 28411, 57557, 116731, 236897, 480881, 976369,1982627, 4026031, &
-      & 8175383, 16601593, 33712729, 68460391, 139022417, 282312799, &
-      & 573292817, 1164186217, 2147483647/)
     do i = 1, size(sizes)
       if (sizes(i) >= n_buckets) then
         this%n_buckets = sizes(i)
         allocate(this%buckets(this%n_buckets))
-        return
+        exit
       endif
     enddo
-
-    stop "Did not expect to need this many buckets."
   end subroutine
 
   function key_count(this)

--- a/fhash.f90
+++ b/fhash.f90
@@ -308,27 +308,23 @@ module FHASH_MODULE_NAME
     bucket_id = modulo(hash_value(key), this%n_buckets) + 1
     first = this%buckets(bucket_id)
 
-    if (allocated(first%kv)) then
-      if (first%kv%key == key) then
-        if (associated(first%next)) then
-          this%buckets(bucket_id)%kv%key =  this%buckets(bucket_id)%next%kv%key
-          this%buckets(bucket_id)%kv%value VALUE_ASSIGNMENT this%buckets(bucket_id)%next%kv%value
-          deallocate(first%next%kv)
-          this%buckets(bucket_id)%next => this%buckets(bucket_id)%next%next
-        else
-          deallocate(this%buckets(bucket_id)%kv)
-        endif
-        locSuccess = .true.
-      else
-        call node_remove(first%next, key, locSuccess, first)
-      end if
-    else
+    if (.not. allocated(first%kv)) then
       locSuccess = .false.
+    elseif (.not. first%kv%key == key) then
+      call node_remove(first%next, key, locSuccess, first)
+    elseif (associated(first%next)) then
+      this%buckets(bucket_id)%kv%key =  this%buckets(bucket_id)%next%kv%key
+      this%buckets(bucket_id)%kv%value VALUE_ASSIGNMENT this%buckets(bucket_id)%next%kv%value
+      deallocate(first%next%kv)
+      this%buckets(bucket_id)%next => this%buckets(bucket_id)%next%next
+      locSuccess = .true.
+    else
+      deallocate(this%buckets(bucket_id)%kv)
+      locSuccess = .true.
     endif
     
     if (locSuccess) this%n_keys = this%n_keys - 1
     if (present(success)) success = locSuccess
-    
   end subroutine
 
   recursive subroutine node_remove(this, key, success, last)

--- a/fhash.f90
+++ b/fhash.f90
@@ -222,6 +222,8 @@ module FHASH_MODULE_NAME
         return
       endif
     enddo
+
+    stop "Did not expect to need this many buckets."
   end subroutine
 
   function key_count(this)

--- a/fhash.f90
+++ b/fhash.f90
@@ -213,8 +213,8 @@ module FHASH_MODULE_NAME
     & 8175383, 16601593, 33712729, 68460391, 139022417, 282312799, &
     & 573292817, 1164186217, 2147483647]
 
-    if (this%key_count() > 0) stop 'Cannot reserve when fhash is not empty.'
-    if (n_buckets > sizes(size(sizes))) stop "Did not expect to need this many buckets."
+    call assert(this%key_count() == 0, 'Cannot reserve when fhash is not empty.')
+    call assert(sizes(size(sizes)) >= n_buckets, "Did not expect to need this many buckets.")
 
     do i = 1, size(sizes)
       if (sizes(i) >= n_buckets) then
@@ -416,6 +416,16 @@ module FHASH_MODULE_NAME
 
   end subroutine
 
+  subroutine assert(condition, msg)
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    logical, intent(in) :: condition
+    character(*), intent(in) :: msg
+
+    if (.not. condition) then
+      write(error_unit, '(a)') msg
+      error stop
+    endif
+  end subroutine
 end module
 
 #undef KEY_TYPE

--- a/fhash.f90
+++ b/fhash.f90
@@ -182,7 +182,7 @@ module FHASH_MODULE_NAME
   end function
 
   function n_collisions(this)
-    class(FHASH_TYPE_NAME), intent(inout) :: this
+    class(FHASH_TYPE_NAME), intent(in) :: this
     integer :: n_collisions
     integer :: i
 

--- a/fhash.f90
+++ b/fhash.f90
@@ -453,7 +453,10 @@ module FHASH_MODULE_NAME
     integer, intent(in) :: key(:)
 
     real(kind(1.0d0)), parameter :: phi = (sqrt(5.0d0) + 1) / 2
-    integer, parameter :: magic_number = nint(2.0d0**bit_size(hash) * (1 - 1 / phi)) ! = 1640531527 for 32 bit
+    ! Do not use `nint` intrinsic, because ifort claims that  "Fortran 2018 specifies that
+    ! "an elemental intrinsic function here be of type integer or character and
+    !  each argument must be an initialization expr of type integer or character":
+    integer, parameter :: magic_number = 0.5d0 + 2.0d0**bit_size(hash) * (1 - 1 / phi)
     integer :: i
 
     hash = 0

--- a/fhash.f90
+++ b/fhash.f90
@@ -227,7 +227,7 @@ module FHASH_MODULE_NAME
   end subroutine
 
   function key_count(this)
-    class(FHASH_TYPE_NAME), intent(inout) :: this
+    class(FHASH_TYPE_NAME), intent(in) :: this
     integer :: key_count
 
     key_count = this%n_keys

--- a/fhash.f90
+++ b/fhash.f90
@@ -23,10 +23,7 @@
 !                                 | accessible.
 ! KEYS_EQUAL_FUNC <function>      | (optional) function that returns whether two keys
 !                                 | are equal. Defaults to `a == b` or `all(a == b)`,
-!                                 | depending on whether KEY_IS_ARRAY is defined.
-!                                 |
-! KEY_IS_ARRAY                    | helps fhash to choose an appropriate key comparison
-!                                 | function (see KEYS_EQUAL_FUNC)
+!                                 | depending on whether the key is a scalar.
 !                                 |
 ! VALUE_USE <use stmt>            | (optional) A use statement that is required to use
 !                                 | a specific type as a value for the FHASH
@@ -197,6 +194,10 @@ module FHASH_MODULE_NAME
     module procedure :: default_hash__int_array
   end interface
 
+  interface all
+    module procedure :: scalar_all
+  end interface
+
   contains
   logical function keys_equal(a, b)
     KEY_TYPE, intent(in) :: a, b
@@ -204,11 +205,7 @@ module FHASH_MODULE_NAME
 #ifdef KEYS_EQUAL_FUNC
     keys_equal = KEYS_EQUAL_FUNC(a, b)
 #else
-#ifdef KEY_IS_ARRAY
     keys_equal = all(a == b)
-#else
-    keys_equal = a == b
-#endif
 #endif
   end function
 
@@ -483,6 +480,12 @@ module FHASH_MODULE_NAME
       ! Compiler bug?
       hash = ieor(hash, key(i) + magic_number + ishft(hash, 6) + ishft(hash, -2))
     enddo
+  end function
+
+  logical function scalar_all(scal)
+    logical, intent(in) :: scal
+
+    scalar_all = scal
   end function
 
   subroutine assert(condition, msg)

--- a/fhash.f90
+++ b/fhash.f90
@@ -115,7 +115,7 @@ module FHASH_MODULE_NAME
       ! Otherwise, fail and return 0
       procedure, non_overridable :: node_remove
       
-      ! Deallocate kv is allocated.
+      ! Deallocate kv if allocated.
       ! Call the clear method of the next node if the next pointer associated.
       ! Deallocate and nullify the next pointer.
       procedure, non_overridable :: node_clear

--- a/fhash.f90
+++ b/fhash.f90
@@ -607,14 +607,12 @@ contains
 
     type(node_type), pointer :: prev, next
 
-    if (.not. associated(node%next)) return
-
-    prev => node%next
+    next => node%next
     do
+      if (.not. associated(next)) return
+      prev => next
       next => prev%next
       deallocate(prev)
-      if (.not. associated(next)) exit
-      prev => next
     enddo
   end subroutine
 

--- a/fhash.f90
+++ b/fhash.f90
@@ -62,7 +62,6 @@
 #endif
   
 module FHASH_MODULE_NAME
-#undef FHASH_MODULE_NAME
 
 #ifdef KEY_USE
   KEY_USE

--- a/fhash.f90
+++ b/fhash.f90
@@ -373,7 +373,6 @@ module FHASH_MODULE_NAME
     if (associated(this%next)) then
       call this%next%node_clear()
       deallocate(this%next)
-      nullify(this%next)
     endif
   end subroutine
 

--- a/fhash.f90
+++ b/fhash.f90
@@ -22,7 +22,11 @@
 ! KEY_TYPE <typename>             | The type of the keys. May require KEY_USE to be
 !                                 | accessible.
 ! KEYS_EQUAL_FUNC <function>      | (optional) function that returns whether two keys
-!                                 | are equal. Defaults to `==`.
+!                                 | are equal. Defaults to `a == b` or `all(a == b)`,
+!                                 | depending on whether KEY_IS_ARRAY is defined.
+!                                 |
+! KEY_IS_ARRAY                    | helps fhash to choose an appropriate key comparison
+!                                 | function (see KEYS_EQUAL_FUNC)
 !                                 |
 ! VALUE_USE <use stmt>            | (optional) A use statement that is required to use
 !                                 | a specific type as a value for the FHASH
@@ -193,7 +197,11 @@ module FHASH_MODULE_NAME
 #ifdef KEYS_EQUAL_FUNC
     keys_equal = KEYS_EQUAL_FUNC(a, b)
 #else
+#ifdef KEY_IS_ARRAY
+    keys_equal = all(a == b)
+#else
     keys_equal = a == b
+#endif
 #endif
   end function
 

--- a/fhash.f90
+++ b/fhash.f90
@@ -175,7 +175,7 @@ module FHASH_MODULE_NAME
   contains
 
   function bucket_count(this)
-    class(FHASH_TYPE_NAME), intent(inout) :: this
+    class(FHASH_TYPE_NAME), intent(in) :: this
     integer :: bucket_count
 
     bucket_count = this%n_buckets

--- a/fhash.f90
+++ b/fhash.f90
@@ -6,19 +6,7 @@
 !
 ! #define                         | meaning
 ! --------------------------------+-----------------------------------------------------
-! SHORTNAME <Name>                | (optional) The name of the type this FHASH table is
-!                                 | for. If set, it overrides all settings that have
-!                                 | have possibly been made for FHASH_MODULE_NAME,
-!                                 | FHASH_TYPE_NAME, FHASH_TYPE_ITERATOR_NAME, and
-!                                 | FHASH_TYPE_KV_TYPE_NAME.
-!                                 |
-! FHASH_MODULE_NAME <Name>        | The name of the module that encapsulates the FHASH
-!                                 | types and functionality
-! FHASH_TYPE_NAME <Name>          | The name of the actual FHASH type
-! FHASH_TYPE_ITERATOR_NAME <Name> | The name of the FHASH type that can iterate through
-!                                 | the whole FHASH
-!                                 |
-! FHASH_TYPE_KV_TYPE_NAME         | The name of the type that stores a key/value pair
+! SHORTNAME <Name>                | The name of the type of FHASH table.
 !                                 |
 ! KEY_USE <use stmt>              | (optional) A use statement that is required to use
 !                                 | a specific type as a key for the FHASH
@@ -40,24 +28,17 @@
 !                                 | anywhere, it is configured based on VALUE_POINTER
 #endif
 
-#ifdef SHORTNAME
-#   undef FHASH_MODULE_NAME
-#   undef FHASH_TYPE_NAME
-#   undef FHASH_TYPE_ITERATOR_NAME
-#   undef FHASH_TYPE_KV_TYPE_NAME
-
-#   ifdef __GFORTRAN__
-#       define PASTE(a) a
-#       define CONCAT(a,b) PASTE(a)b
-#   else
-#       define PASTE(a,b) a ## b
-#       define CONCAT(a,b) PASTE(a,b)
-#   endif
-#   define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
-#   define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
-#   define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
-#   define FHASH_TYPE_KV_TYPE_NAME CONCAT(fhash_type_kv__,SHORTNAME)
+#ifdef __GFORTRAN__
+#    define PASTE(a) a
+#    define CONCAT(a,b) PASTE(a)b
+#else
+#    define PASTE(a,b) a ## b
+#    define CONCAT(a,b) PASTE(a,b)
 #endif
+#define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
+#define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
+#define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
+#define FHASH_TYPE_KV_TYPE_NAME CONCAT(fhash_type_kv__,SHORTNAME)
 
 ! For some bizar reason both gfortran-10 and ifort-2021.4 fail to compile, unless
 ! this function has a unique name for every time that this file is included:
@@ -493,6 +474,7 @@ contains
 
     global_compare_ptr => compare
     global_sorted_kv_list_ptr => kv_list
+    allocate(perm(size(kv_list)))
     perm = sorting_perm()
     kv_list = kv_list(perm)
 
@@ -730,6 +712,12 @@ contains
   end function
 end module
 
+#undef SHORTNAME
+#undef FHASH_MODULE_NAME
+#undef FHASH_TYPE_NAME
+#undef FHASH_TYPE_ITERATOR_NAME
+#undef FHASH_TYPE_KV_TYPE_NAME
+#undef HASH_FUNC
 #undef _FINAL_IS_IMPLEMENTED
 #undef _FINAL_TYPEORCLASS
 #undef __COMPARE_AT_IDX
@@ -738,10 +726,5 @@ end module
 #undef VALUE_TYPE
 #undef VALUE_TYPE_INIT
 #undef VALUE_ASSIGNMENT
-#undef FHASH_TYPE_NAME
-#undef HASH_FUNC
-#undef FHASH_TYPE_ITERATOR_NAME
-#undef FHASH_TYPE_KV_TYPE_NAME
-#undef SHORTNAME
 #undef CONCAT
 #undef PASTE

--- a/fhash.f90
+++ b/fhash.f90
@@ -104,22 +104,12 @@ module FHASH_MODULE_NAME
       
       ! Return the length of the linked list start from the current node.
       procedure, non_overridable :: node_depth
-      
-      ! Deallocate kv if allocated.
-      ! Call the clear method of the next node if the next pointer associated.
-      ! Deallocate and nullify the next pointer.
-      !
-      ! Need separate finalizers because a resursive procedure cannot be elemental.
-#ifdef _FINAL_IS_IMPLEMENTED
-      final :: clear_scalar_node
-      final :: clear_rank1_nodes
-#else
-      ! Old `gfortran` versions think the passed dummy must be a scalar:
-      generic, public :: clear => clear_scalar_node
-      procedure, non_overridable, private :: clear_scalar_node
-      ! procedure, non_overridable, private :: clear_rank1_nodes
-#endif
-    end type
+
+      ! No FINAL procedure here, because it would have to be recursive (at least
+      ! implicitly, because it finalizes the 'next' pointer), and a recursive
+      ! procedure is not performant.
+      ! Fortunately this type is not public, and it gets deallocated when finalizing the fhash.
+  end type
 
   type FHASH_TYPE_NAME
     private
@@ -590,8 +580,16 @@ contains
   impure elemental subroutine clear(this)
     class(FHASH_TYPE_NAME), intent(inout) :: this
 
+    integer :: i
+
     this%n_keys = 0
-    if (associated(this%buckets)) deallocate(this%buckets)
+    if (associated(this%buckets)) then
+      do i = 1, size(this%buckets)
+        call clear_children(this%buckets(i))
+        if (allocated(this%buckets(i)%kv)) deallocate(this%buckets(i)%kv)
+      enddo
+      deallocate(this%buckets)
+    endif
   end subroutine
 
 #ifdef _FINAL_IS_IMPLEMENTED
@@ -601,6 +599,24 @@ contains
     call this%clear()
   end subroutine
 #endif
+
+  subroutine clear_children(node)
+    ! Not a recursive subroutine, because (i) this is much more performant, and
+    ! (ii) gfortran thinks that it cannot be both elemental and recursive.
+    _FINAL_TYPEORCLASS(node_type), intent(inout) :: node
+
+    type(node_type), pointer :: prev, next
+
+    if (.not. associated(node%next)) return
+
+    prev => node%next
+    do
+      next => prev%next
+      deallocate(prev)
+      if (.not. associated(next)) exit
+      prev => next
+    enddo
+  end subroutine
 
   integer function key2bucket(this, key) result(bucket_id)
     class(FHASH_TYPE_NAME), intent(in) :: this
@@ -615,26 +631,6 @@ contains
 #endif
     bucket_id = modulo(hash, size(this%buckets)) + 1
   end function
-
-
-  subroutine clear_rank1_nodes(nodes)
-    _FINAL_TYPEORCLASS(node_type), intent(inout) :: nodes(:)
-
-    integer :: i
-
-    do i = 1, size(nodes)
-      call clear_scalar_node(nodes(i))
-    enddo
-  end subroutine
-
-  recursive subroutine clear_scalar_node(node)
-    _FINAL_TYPEORCLASS(node_type), intent(inout) :: node
-
-    if (associated(node%next)) then
-      call clear_scalar_node(node%next)
-      deallocate(node%next)
-    endif
-  end subroutine
 
   subroutine begin(this, fhash_target)
     class(FHASH_TYPE_ITERATOR_NAME), intent(inout) :: this

--- a/fhash.f90
+++ b/fhash.f90
@@ -268,7 +268,7 @@ module FHASH_MODULE_NAME
   end subroutine
 
   subroutine get(this, key, value, success)
-    class(FHASH_TYPE_NAME), intent(inout) :: this
+    class(FHASH_TYPE_NAME), intent(in) :: this
     KEY_TYPE, intent(in) :: key
     VALUE_TYPE, intent(out) :: value
     logical, optional, intent(out) :: success

--- a/fhash.f90
+++ b/fhash.f90
@@ -273,7 +273,7 @@ contains
     enddo
   end subroutine
 
-  function key_count(this)
+  impure elemental function key_count(this)
     class(FHASH_TYPE_NAME), intent(in) :: this
     integer :: key_count
 

--- a/fhash.f90
+++ b/fhash.f90
@@ -193,7 +193,7 @@ module FHASH_MODULE_NAME
   end function
 
   recursive function node_depth(this) result(depth)
-    class(node_type), intent(inout) :: this
+    class(node_type), intent(in) :: this
     integer :: depth
 
     if (.not. associated(this%next)) then

--- a/fhash.f90
+++ b/fhash.f90
@@ -255,7 +255,7 @@ contains
   end function
 
   impure elemental subroutine reserve(this, n_buckets)
-    class(FHASH_TYPE_NAME), intent(inout) :: this
+    class(FHASH_TYPE_NAME), intent(out) :: this
     integer, intent(in) :: n_buckets
 
     integer :: i
@@ -263,12 +263,12 @@ contains
     & 28411, 57557, 116731, 236897, 480881, 976369,1982627, 4026031, &
     & 8175383, 16601593, 33712729, 68460391, 139022417, 282312799, &
     & 573292817, 1164186217, 2147483647]
+    integer, parameter :: n = size(sizes)
 
-    call assert(this%key_count() == 0, 'Cannot reserve when fhash is not empty.')
-    call assert(n_buckets >= 1, "I need at least one bucket.")
-    call assert(sizes(size(sizes)) >= n_buckets, "Did not expect to need this many buckets.")
+    call assert(sizes(2:) - sizes(:n-1) > 0, "PROGRAMMING ERROR: sizes should be strictly increasing")
+    call assert(sizes(n) >= n_buckets, "Did not expect to need this many buckets.")
 
-    do i = 1, size(sizes)
+    do i = 1, n
       if (sizes(i) >= n_buckets) then
         allocate(this%buckets(sizes(i)))
         exit
@@ -708,7 +708,7 @@ contains
     scalar_all = scal
   end function
 
-  subroutine assert(condition, msg)
+  impure elemental subroutine assert(condition, msg)
     use, intrinsic :: iso_fortran_env, only: error_unit
     logical, intent(in) :: condition
     character(*), intent(in) :: msg

--- a/fhash.f90
+++ b/fhash.f90
@@ -241,7 +241,7 @@ module FHASH_MODULE_NAME
     endif
   end function
 
-  subroutine reserve(this, n_buckets)
+  impure elemental subroutine reserve(this, n_buckets)
     class(FHASH_TYPE_NAME), intent(inout) :: this
     integer, intent(in) :: n_buckets
 
@@ -383,7 +383,7 @@ module FHASH_MODULE_NAME
     endif
   end subroutine
 
-  subroutine clear(this)
+  impure elemental subroutine clear(this)
     class(FHASH_TYPE_NAME), intent(out) :: this
   end subroutine
   

--- a/fhash.f90
+++ b/fhash.f90
@@ -382,6 +382,7 @@ module FHASH_MODULE_NAME
     type(FHASH_TYPE_NAME), target, intent(in) :: fhash_target
 
     this%bucket_id = 1
+    call assert(allocated(fhash_target%buckets), "cannot start iteration when fhash is empty")
     this%node_ptr => fhash_target%buckets(1)
     this%fhash_ptr => fhash_target
   end subroutine

--- a/fhash.f90
+++ b/fhash.f90
@@ -392,7 +392,11 @@ module FHASH_MODULE_NAME
     VALUE_TYPE, intent(out) :: value
     integer, optional, intent(out) :: status
 
-    do while (.not. associated(this%node_ptr) .or. .not. allocated(this%node_ptr%kv))
+    do
+      if (associated(this%node_ptr)) then
+        if (allocated(this%node_ptr%kv)) exit
+      endif
+
       if (this%bucket_id < this%fhash_ptr%n_buckets) then
         this%bucket_id = this%bucket_id + 1
         this%node_ptr => this%fhash_ptr%buckets(this%bucket_id)

--- a/fhash.f90
+++ b/fhash.f90
@@ -332,10 +332,10 @@ contains
     else if (keys_equal(this%kv%key, key)) then
       value VALUE_ASSIGNMENT this%kv%value
       if (present(success)) success = .true.
-    else if (associated(this%next)) then
+    elseif (.not. associated(this%next)) then
+      if (present(success)) success = .false.
+    else
       call node_get(this%next, key, value, success)
-    elseif (present(success)) then
-      success = .false.
     endif
   end subroutine
   

--- a/fhash.f90
+++ b/fhash.f90
@@ -249,6 +249,7 @@ module FHASH_MODULE_NAME
     & 573292817, 1164186217, 2147483647]
 
     call assert(this%key_count() == 0, 'Cannot reserve when fhash is not empty.')
+    call assert(n_buckets >= 1, "I need at least one bucket.")
     call assert(sizes(size(sizes)) >= n_buckets, "Did not expect to need this many buckets.")
 
     do i = 1, size(sizes)

--- a/fhash.f90
+++ b/fhash.f90
@@ -56,6 +56,7 @@
 #   define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
 #   define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
 #   define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
+#   define FHASH_TYPE_KV_TYPE_NAME CONCAT(fhash_type_kv__,SHORTNAME)
 #endif
 
 #ifdef VALUE_POINTER
@@ -169,6 +170,9 @@ module FHASH_MODULE_NAME
 
       ! Remove the value with the given key.
       procedure, non_overridable, public :: remove
+
+      ! Get the key/value pairs as a list:
+      procedure, non_overridable, public :: as_list
 
       ! Return the accumalated storage size of an fhash, including the underlying pointers.
       ! Takes the bit size of a key-value pair as an argument.
@@ -441,6 +445,23 @@ module FHASH_MODULE_NAME
     else
       success = .false.
     endif
+  end subroutine
+
+  subroutine as_list(this, kv_list)
+    class(FHASH_TYPE_NAME), target, intent(in) :: this
+    type(FHASH_TYPE_KV_TYPE_NAME), allocatable, intent(out) :: kv_list(:)
+
+    integer :: i, n
+    type(FHASH_TYPE_ITERATOR_NAME) :: iter
+    integer :: iter_stat
+
+    n = this%key_count()
+    allocate(kv_list(n))
+    call iter%begin(this)
+    do i = 1, n
+      call iter%next(kv_list(i)%key, kv_list(i)%value, iter_stat)
+      call assert(iter_stat == 0, "as_list: internal error: iterator stopped unexpectedly")
+    enddo
   end subroutine
 
   impure elemental subroutine deepcopy_fhash(lhs, rhs)

--- a/fhash.f90
+++ b/fhash.f90
@@ -98,13 +98,13 @@ module FHASH_MODULE_NAME
       ! If kv is not allocated, allocate and set to the key, value passed in.
       ! If key is present and the same as the key passed in, overwrite the value.
       ! Otherwise, defer to the next node (allocate if not allocated)
-      procedure :: node_set
+      procedure, non_overridable :: node_set
 
       ! If kv is not allocated, fail and return 0.
       ! If key is present and the same as the key passed in, return the value in kv.
       ! If next pointer is associated, delegate to it.
       ! Otherwise, fail and return 0.
-      procedure :: node_get
+      procedure, non_overridable :: node_get
 
       ! If kv is not allocated, fail and return
       ! If key is present and node is first in bucket, set first node in bucket to 
@@ -113,15 +113,15 @@ module FHASH_MODULE_NAME
       !   previous node's next node to this node's next node, deallocate this node, 
       !   return success
       ! Otherwise, fail and return 0
-      procedure :: node_remove
+      procedure, non_overridable :: node_remove
       
       ! Deallocate kv is allocated.
       ! Call the clear method of the next node if the next pointer associated.
       ! Deallocate and nullify the next pointer.
-      procedure :: node_clear
+      procedure, non_overridable :: node_clear
 
       ! Return the length of the linked list start from the current node.
-      procedure :: node_depth
+      procedure, non_overridable :: node_depth
   end type
 
   type FHASH_TYPE_NAME
@@ -133,28 +133,28 @@ module FHASH_MODULE_NAME
 
     contains
       ! Returns the number of buckets.
-      procedure, public :: bucket_count
+      procedure, non_overridable, public :: bucket_count
 
       ! Return the number of collisions.
-      procedure, public :: n_collisions
+      procedure, non_overridable, public :: n_collisions
 
       ! Reserve certain number of buckets.
-      procedure, public :: reserve
+      procedure, non_overridable, public :: reserve
 
       ! Returns number of keys.
-      procedure, public :: key_count
+      procedure, non_overridable, public :: key_count
 
       ! Set the value at a given a key.
-      procedure, public :: set
+      procedure, non_overridable, public :: set
 
       ! Get the value at the given key.
-      procedure, public :: get
+      procedure, non_overridable, public :: get
 
       ! Remove the value with the given key.
-      procedure, public :: remove
+      procedure, non_overridable, public :: remove
 
       ! Clear all the allocated memory (must be called to prevent memory leak).
-      procedure, public :: clear
+      procedure, non_overridable, public :: clear
   end type
 
   type FHASH_TYPE_ITERATOR_NAME
@@ -166,10 +166,10 @@ module FHASH_MODULE_NAME
 
     contains
       ! Set the iterator to the beginning of a hash table.
-      procedure, public :: begin
+      procedure, non_overridable, public :: begin
 
       ! Get the key value of the next element and advance the iterator.
-      procedure, public :: next
+      procedure, non_overridable, public :: next
   end type
 
   contains

--- a/fhash.f90
+++ b/fhash.f90
@@ -6,7 +6,7 @@
 !
 ! #define                         | meaning
 ! --------------------------------+-----------------------------------------------------
-! SHORTNAME <Name>                | The name of the type of FHASH table.
+! FHASH_NAME <Name>               | The name of the type of FHASH table.
 !                                 |
 ! KEY_USE <use stmt>              | (optional) A use statement that is required to use
 !                                 | a specific type as a key for the FHASH
@@ -35,14 +35,14 @@
 #    define PASTE(a,b) a ## b
 #    define CONCAT(a,b) PASTE(a,b)
 #endif
-#define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
-#define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
-#define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
-#define FHASH_TYPE_KV_TYPE_NAME CONCAT(fhash_type_kv__,SHORTNAME)
+#define FHASH_MODULE_NAME CONCAT(FHASH_NAME,_mod)
+#define FHASH_TYPE_NAME CONCAT(FHASH_NAME,_t)
+#define FHASH_TYPE_ITERATOR_NAME CONCAT(FHASH_NAME,_iter_t)
+#define FHASH_TYPE_KV_TYPE_NAME CONCAT(FHASH_NAME,_kv_t)
 
 ! For some bizar reason both gfortran-10 and ifort-2021.4 fail to compile, unless
 ! this function has a unique name for every time that this file is included:
-#define __COMPARE_AT_IDX CONCAT(fhash_type_compare__,SHORTNAME)
+#define __COMPARE_AT_IDX CONCAT(fhash_type_compare__,FHASH_NAME)
 
 #ifdef VALUE_POINTER
 #   define VALUE_ASSIGNMENT =>
@@ -712,7 +712,7 @@ contains
   end function
 end module
 
-#undef SHORTNAME
+#undef FHASH_NAME
 #undef FHASH_MODULE_NAME
 #undef FHASH_TYPE_NAME
 #undef FHASH_TYPE_ITERATOR_NAME

--- a/fhash.f90
+++ b/fhash.f90
@@ -115,13 +115,16 @@ module FHASH_MODULE_NAME
       ! Otherwise, fail and return 0
       procedure, non_overridable :: node_remove
       
+      ! Return the length of the linked list start from the current node.
+      procedure, non_overridable :: node_depth
+      
       ! Deallocate kv if allocated.
       ! Call the clear method of the next node if the next pointer associated.
       ! Deallocate and nullify the next pointer.
-      procedure, non_overridable :: node_clear
-
-      ! Return the length of the linked list start from the current node.
-      procedure, non_overridable :: node_depth
+      !
+      ! Need separate finalizers because a resursive procedure cannot be elemental.
+      final :: clear_scalar_node
+      final :: clear_rank1_nodes
   end type
 
   type FHASH_TYPE_NAME
@@ -153,7 +156,7 @@ module FHASH_MODULE_NAME
       ! Remove the value with the given key.
       procedure, non_overridable, public :: remove
 
-      ! Clear all the allocated memory (must be called to prevent memory leak).
+      ! Clear all the allocated memory
       procedure, non_overridable, public :: clear
   end type
 
@@ -347,28 +350,25 @@ module FHASH_MODULE_NAME
   end subroutine
 
   subroutine clear(this)
-    class(FHASH_TYPE_NAME), intent(inout) :: this
-    integer :: i
-
-    if (.not. allocated(this%buckets)) return
-
-    do i = 1, size(this%buckets)
-      if (associated(this%buckets(i)%next)) then
-        call this%buckets(i)%next%node_clear()
-        deallocate(this%buckets(i)%next)
-      endif
-    enddo
-    deallocate(this%buckets)
-    this%n_keys = 0
-    this%n_buckets = 0
+    class(FHASH_TYPE_NAME), intent(out) :: this
   end subroutine
 
-  recursive subroutine node_clear(this)
-    class(node_type), intent(inout) :: this
+  subroutine clear_rank1_nodes(nodes)
+    type(node_type), intent(inout) :: nodes(:)
 
-    if (associated(this%next)) then
-      call this%next%node_clear()
-      deallocate(this%next)
+    integer :: i
+
+    do i = 1, size(nodes)
+      call clear_scalar_node(nodes(i))
+    enddo
+  end subroutine
+
+  recursive subroutine clear_scalar_node(node)
+    type(node_type), intent(inout) :: node
+
+    if (associated(node%next)) then
+      call clear_scalar_node(node%next)
+      deallocate(node%next)
     endif
   end subroutine
 

--- a/fhash.f90
+++ b/fhash.f90
@@ -485,14 +485,15 @@ contains
 
   subroutine as_list(this, kv_list)
     class(FHASH_TYPE_NAME), target, intent(in) :: this
-    type(FHASH_TYPE_KV_TYPE_NAME), allocatable, intent(out) :: kv_list(:)
+    type(FHASH_TYPE_KV_TYPE_NAME), intent(out) :: kv_list(:)
 
     integer :: i, n
     type(FHASH_TYPE_ITERATOR_NAME) :: iter
     integer :: iter_stat
-
+    
     n = this%key_count()
-    allocate(kv_list(n))
+    call assert(size(kv_list) == n, "as_list: kv_list has a bad size")
+
     call iter%begin(this)
     do i = 1, n
       call iter%next(kv_list(i)%key, kv_list(i)%value, iter_stat)
@@ -502,7 +503,7 @@ contains
 
   subroutine as_sorted_list(this, kv_list, compare)
     class(FHASH_TYPE_NAME), target, intent(in) :: this
-    type(FHASH_TYPE_KV_TYPE_NAME), target, allocatable, intent(out) :: kv_list(:)
+    type(FHASH_TYPE_KV_TYPE_NAME), target, intent(out) :: kv_list(:)
     procedure(compare_keys_i) :: compare
 
     call this%as_list(kv_list)

--- a/fhash.f90
+++ b/fhash.f90
@@ -61,7 +61,6 @@
 #define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
 #endif
 
-#undef VALUE_ASSIGNMENT
 #ifndef VALUE_VALUE
 #ifndef VALUE_POINTER
 #define VALUE_VALUE

--- a/fhash.f90
+++ b/fhash.f90
@@ -3,17 +3,17 @@
 ! DO NOT COMPILE THIS TEMPLATE FILE DIRECTLY.
 ! Use a wrapper module and include this file instead, e.g. fhash_modules.f90.
 ! Remove is not implemented since not needed currently.
-!  
+!
 ! #define                         | meaning
 ! --------------------------------+-----------------------------------------------------
-! SHORTNAME <Name>                | (optional) The name of the type this FHASH table is 
-!                                 | for. If set, it overrides all settings that have 
+! SHORTNAME <Name>                | (optional) The name of the type this FHASH table is
+!                                 | for. If set, it overrides all settings that have
 !                                 | have possibly been made for FHASH_MODULE_NAME,
 !                                 | FHASH_TYPE_NAME and FHASH_TYPE_ITERATOR_NAME.
 !                                 |
 ! FHASH_MODULE_NAME <Name>        | The name of the module that encapsulates the FHASH
 !                                 | types and functionality
-! FHASH_TYPE_NAME <Name>          | The name of the actual FHASH type 
+! FHASH_TYPE_NAME <Name>          | The name of the actual FHASH type
 ! FHASH_TYPE_ITERATOR_NAME <Name> | The name of the FHASH type that can iterate through
 !                                 | the whole FHASH
 !                                 |
@@ -31,7 +31,7 @@
 !                                 | values. This is the default. (see VALUE_POINTER)
 ! VALUE_POINTER                   | Flag indicating that the values in FHASH are value
 !                                 | pointers.
-! VALUE_ASSIGNMENT                | (internal) The assignment operator, do not set it 
+! VALUE_ASSIGNMENT                | (internal) The assignment operator, do not set it
 !                                 | anywhere, it is configured based on VALUE_VALUE or
 !                                 | VALUE_POINTER
 #endif
@@ -107,10 +107,10 @@ module FHASH_MODULE_NAME
       procedure, non_overridable :: node_get
 
       ! If kv is not allocated, fail and return
-      ! If key is present and node is first in bucket, set first node in bucket to 
+      ! If key is present and node is first in bucket, set first node in bucket to
       !   the next node of first. Return success
-      ! If key is present and the node is another member of the linked list, link the 
-      !   previous node's next node to this node's next node, deallocate this node, 
+      ! If key is present and the node is another member of the linked list, link the
+      !   previous node's next node to this node's next node, deallocate this node,
       !   return success
       ! Otherwise, fail and return 0
       procedure, non_overridable :: node_remove
@@ -315,7 +315,7 @@ module FHASH_MODULE_NAME
           this%buckets(bucket_id)%kv%key =  this%buckets(bucket_id)%next%kv%key
           this%buckets(bucket_id)%kv%value VALUE_ASSIGNMENT this%buckets(bucket_id)%next%kv%value
           deallocate(first%next%kv)
-          this%buckets(bucket_id)%next => this%buckets(bucket_id)%next%next 
+          this%buckets(bucket_id)%next => this%buckets(bucket_id)%next%next
         else
           deallocate(this%buckets(bucket_id)%kv)
         endif
@@ -324,7 +324,7 @@ module FHASH_MODULE_NAME
         call node_remove(first%next, key, locSuccess, first)
       end if
     else
-      locSuccess = .false.      
+      locSuccess = .false.
     endif
     
     if (locSuccess) this%n_keys = this%n_keys - 1
@@ -359,7 +359,7 @@ module FHASH_MODULE_NAME
     if (.not. allocated(this%buckets)) return
 
     do i = 1, size(this%buckets)
-      if (associated(this%buckets(i)%next)) then 
+      if (associated(this%buckets(i)%next)) then
         call this%buckets(i)%next%node_clear()
         deallocate(this%buckets(i)%next)
       endif
@@ -382,7 +382,7 @@ module FHASH_MODULE_NAME
     class(FHASH_TYPE_ITERATOR_NAME), intent(inout) :: this
     type(FHASH_TYPE_NAME), target, intent(in) :: fhash_target
 
-    this%bucket_id = 1 
+    this%bucket_id = 1
     this%node_ptr => fhash_target%buckets(1)
     this%fhash_ptr => fhash_target
   end subroutine
@@ -405,7 +405,7 @@ module FHASH_MODULE_NAME
         if (present(status)) status = -1
 #ifdef VALUE_TYPE_INIT
         value VALUE_ASSIGNMENT VALUE_TYPE_INIT
-#endif        
+#endif
         return
       endif
     enddo

--- a/fhash.f90
+++ b/fhash.f90
@@ -279,7 +279,7 @@ module FHASH_MODULE_NAME
   end subroutine
 
   recursive subroutine node_get(this, key, value, success)
-    class(node_type), intent(inout) :: this
+    class(node_type), intent(in) :: this
     KEY_TYPE, intent(in) :: key
     VALUE_TYPE, intent(out) :: value
     logical, optional, intent(out) :: success

--- a/fhash.f90
+++ b/fhash.f90
@@ -475,7 +475,6 @@ contains
       success = .false.
     else if (keys_equal(next%kv%key, key)) then
       last%next => next%next
-      nullify(next%next)
       deallocate(next%kv)
       success = .true.
     else if (.not. associated(next%next)) then

--- a/fhash.f90
+++ b/fhash.f90
@@ -9,13 +9,16 @@
 ! SHORTNAME <Name>                | (optional) The name of the type this FHASH table is
 !                                 | for. If set, it overrides all settings that have
 !                                 | have possibly been made for FHASH_MODULE_NAME,
-!                                 | FHASH_TYPE_NAME and FHASH_TYPE_ITERATOR_NAME.
+!                                 | FHASH_TYPE_NAME, FHASH_TYPE_ITERATOR_NAME, and
+!                                 | FHASH_TYPE_KV_TYPE_NAME.
 !                                 |
 ! FHASH_MODULE_NAME <Name>        | The name of the module that encapsulates the FHASH
 !                                 | types and functionality
 ! FHASH_TYPE_NAME <Name>          | The name of the actual FHASH type
 ! FHASH_TYPE_ITERATOR_NAME <Name> | The name of the FHASH type that can iterate through
 !                                 | the whole FHASH
+!                                 |
+! FHASH_TYPE_KV_TYPE_NAME         | The name of the type that stores a key/value pair
 !                                 |
 ! KEY_USE <use stmt>              | (optional) A use statement that is required to use
 !                                 | a specific type as a key for the FHASH
@@ -38,26 +41,27 @@
 #endif
 
 #ifdef SHORTNAME
-#undef FHASH_MODULE_NAME
-#undef FHASH_TYPE_NAME
-#undef FHASH_TYPE_ITERATOR_NAME
+#   undef FHASH_MODULE_NAME
+#   undef FHASH_TYPE_NAME
+#   undef FHASH_TYPE_ITERATOR_NAME
+#   undef FHASH_TYPE_KV_TYPE_NAME
 
-#ifdef __GFORTRAN__
-#define PASTE(a) a
-#define CONCAT(a,b) PASTE(a)b
-#else
-#define PASTE(a,b) a ## b
-#define CONCAT(a,b) PASTE(a,b)
-#endif
-#define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
-#define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
-#define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
+#   ifdef __GFORTRAN__
+#       define PASTE(a) a
+#       define CONCAT(a,b) PASTE(a)b
+#   else
+#       define PASTE(a,b) a ## b
+#       define CONCAT(a,b) PASTE(a,b)
+#   endif
+#   define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
+#   define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
+#   define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
 #endif
 
 #ifdef VALUE_POINTER
-#define VALUE_ASSIGNMENT =>
+#   define VALUE_ASSIGNMENT =>
 #else
-#define VALUE_ASSIGNMENT =
+#   define VALUE_ASSIGNMENT =
 #endif
 
 ! Not all compilers implement finalization:
@@ -89,14 +93,15 @@ module FHASH_MODULE_NAME
 
   public :: FHASH_TYPE_NAME
   public :: FHASH_TYPE_ITERATOR_NAME
+  public :: FHASH_TYPE_KV_TYPE_NAME
 
-  type kv_type
+  type :: FHASH_TYPE_KV_TYPE_NAME
     KEY_TYPE :: key
     VALUE_TYPE :: value
   end type
 
-  type node_type
-    type(kv_type), allocatable :: kv
+  type :: node_type
+    type(FHASH_TYPE_KV_TYPE_NAME), allocatable :: kv
     type(node_type), pointer :: next => null()
 
     contains

--- a/fhash.f90
+++ b/fhash.f90
@@ -35,13 +35,9 @@
 ! 
 ! HASH_FUNC                       | (optional) hash function name. Defaults to 'hash'.
 !                                 |
-! VALUE_VALUE                     | Flag indicating that the values in FHASH are value
-!                                 | values. This is the default. (see VALUE_POINTER)
-! VALUE_POINTER                   | Flag indicating that the values in FHASH are value
-!                                 | pointers.
+! VALUE_POINTER                   | (optional) If defined, the values are pointers.
 ! VALUE_ASSIGNMENT                | (internal) The assignment operator, do not set it
-!                                 | anywhere, it is configured based on VALUE_VALUE or
-!                                 | VALUE_POINTER
+!                                 | anywhere, it is configured based on VALUE_POINTER
 #endif
 
 #ifdef SHORTNAME
@@ -59,12 +55,6 @@
 #define FHASH_MODULE_NAME CONCAT(fhash_module__,SHORTNAME)
 #define FHASH_TYPE_NAME CONCAT(fhash_type__,SHORTNAME)
 #define FHASH_TYPE_ITERATOR_NAME CONCAT(fhash_type_iterator__,SHORTNAME)
-#endif
-
-#ifndef VALUE_VALUE
-#ifndef VALUE_POINTER
-#define VALUE_VALUE
-#endif
 #endif
 
 #ifdef VALUE_POINTER

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -1,5 +1,4 @@
 ! Define the module for the key type.
-! Override the hash_value and == operator interface.
 module ints_module
 
   implicit none
@@ -11,12 +10,6 @@ module ints_module
   interface hash_value
     module procedure hash_value_ints
   end interface
-
-#ifdef __GFORTRAN__
-  interface assignment (=)
-    module procedure ints_ptr_assign
-  end interface
-#endif
 
 contains
 
@@ -57,15 +50,6 @@ contains
     ints_equal = .true.
 
   end function
-
-#ifdef __GFORTRAN__
-  subroutine ints_ptr_assign(lhs, rhs)
-    type(ints_type), pointer, intent(out) :: lhs
-    type(ints_type), target, intent(in) :: rhs
-    lhs => rhs
-  end subroutine
-#endif
-
 end module ints_module
 
 ! Define the macros needed by fhash and include fhash.f90
@@ -85,9 +69,7 @@ end module ints_module
 #define VALUE_TYPE type(ints_type), pointer
 !#define VALUE_TYPE_INIT null()
 #define SHORTNAME int_ints_ptr
-#ifndef __GFORTRAN__
 #define VALUE_POINTER
-#endif
 #ifdef VALUE_TYPE_INIT
 #define CHECK_ITERATOR_VALUE
 #endif

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -60,8 +60,8 @@ module ints_module
 
 #ifdef __GFORTRAN__
     subroutine ints_ptr_assign(lhs, rhs)
-      type(ints_type), pointer, intent(inout) :: lhs
-      type(ints_type), pointer, intent(in) :: rhs
+      type(ints_type), pointer, intent(out) :: lhs
+      type(ints_type), target, intent(in) :: rhs
       lhs => rhs
     end subroutine
 #endif

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -79,30 +79,11 @@ end module ints_module
 #define SHORTNAME ints_double
 #include "fhash.f90"
 
-module int_module
-  implicit none
-
-  interface hash_value
-    module procedure hash_value_int
-  end interface
-
-  contains
-
-    function hash_value_int(int) result(hash)
-      integer, intent(in) :: int
-      integer :: hash
-
-      hash = int
-    end function
-end module
-
 ! Define the macros needed by fhash and include fhash.f90
-#define KEY_USE use int_module
 #define KEY_TYPE integer
 #define VALUE_USE use ints_module
 #define VALUE_TYPE type(ints_type), pointer
 !#define VALUE_TYPE_INIT null()
-#define HASH_FUNC hash_value
 #define SHORTNAME int_ints_ptr
 #ifndef __GFORTRAN__
 #define VALUE_POINTER

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -1,4 +1,4 @@
-#define SHORTNAME i2char
+#define FHASH_NAME i2char
 #define KEY_TYPE integer
 #define VALUE_TYPE character(10)
 #include "fhash.f90"
@@ -61,7 +61,7 @@ contains
 end module ints_module
 
 ! Define the macros needed by fhash and include fhash.f90
-#define SHORTNAME ints_double
+#define FHASH_NAME ints_double
 #define KEY_USE use ints_module
 #define KEY_TYPE type(ints_type)
 #define KEYS_EQUAL_FUNC ints_equal
@@ -72,7 +72,7 @@ end module ints_module
 #include "fhash.f90"
 
 ! Define the macros needed by fhash and include fhash.f90
-#define SHORTNAME int_ints_ptr
+#define FHASH_NAME int_ints_ptr
 #define KEY_TYPE integer
 #define VALUE_USE use ints_module
 #define VALUE_TYPE type(ints_type), pointer

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -12,10 +12,6 @@ module ints_module
     module procedure hash_value_ints
   end interface
 
-  interface operator (==)
-    module procedure ints_equal
-  end interface
-
 #ifdef __GFORTRAN__
   interface assignment (=)
     module procedure ints_ptr_assign
@@ -77,6 +73,7 @@ end module ints_module
 ! Define the macros needed by fhash and include fhash.f90
 #define KEY_USE use ints_module
 #define KEY_TYPE type(ints_type)
+#define KEYS_EQUAL_FUNC ints_equal
 #define VALUE_USE use, intrinsic :: iso_fortran_env
 #define VALUE_TYPE real(real64)
 #define VALUE_TYPE_INIT 0.0

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -15,55 +15,55 @@ module ints_module
 #ifdef __GFORTRAN__
   interface assignment (=)
     module procedure ints_ptr_assign
-  end interface 
+  end interface
 #endif
-  
-  contains
 
-    function hash_value_ints(ints) result(hash)
-      use, intrinsic :: iso_fortran_env, only: int64, real64
-      type(ints_type), intent(in) :: ints
-      integer(kind(ints%ints)) :: hash
+contains
 
-      real(real64), parameter :: phi = (sqrt(5.0_real64) + 1) / 2
-      integer, parameter :: magic_number = nint(2.0_real64**bit_size(hash) * (1 - 1 / phi)) ! = 1640531527 for 32 bit
-      integer :: i
+  function hash_value_ints(ints) result(hash)
+    use, intrinsic :: iso_fortran_env, only: int64, real64
+    type(ints_type), intent(in) :: ints
+    integer(kind(ints%ints)) :: hash
 
-      hash = 0
-      do i = 1, size(ints%ints)
-        ! This triggers an error in `gfortran` (version 9.3.0) with the `-ftrapv` option.
-        ! Compiler bug?
-        hash = ieor(hash, ints%ints(i) + magic_number + ishft(hash, 6) + ishft(hash, -2))
-      enddo
-    end function
+    real(real64), parameter :: phi = (sqrt(5.0_real64) + 1) / 2
+    integer, parameter :: magic_number = nint(2.0_real64**bit_size(hash) * (1 - 1 / phi)) ! = 1640531527 for 32 bit
+    integer :: i
 
-    function ints_equal(lhs, rhs)
-      type(ints_type), intent(in) :: lhs, rhs
-      logical :: ints_equal
-      integer :: i
+    hash = 0
+    do i = 1, size(ints%ints)
+      ! This triggers an error in `gfortran` (version 9.3.0) with the `-ftrapv` option.
+      ! Compiler bug?
+      hash = ieor(hash, ints%ints(i) + magic_number + ishft(hash, 6) + ishft(hash, -2))
+    enddo
+  end function
 
-      if (size(lhs%ints) /= size(rhs%ints)) then
+  function ints_equal(lhs, rhs)
+    type(ints_type), intent(in) :: lhs, rhs
+    logical :: ints_equal
+    integer :: i
+
+    if (size(lhs%ints) /= size(rhs%ints)) then
+      ints_equal = .false.
+      return
+    endif
+
+    do i = 1, size(lhs%ints)
+      if (lhs%ints(i) /= rhs%ints(i)) then
         ints_equal = .false.
         return
       endif
+    enddo
 
-      do i = 1, size(lhs%ints)
-        if (lhs%ints(i) /= rhs%ints(i)) then
-          ints_equal = .false.
-          return
-        endif
-      enddo
+    ints_equal = .true.
 
-      ints_equal = .true.
-
-    end function
+  end function
 
 #ifdef __GFORTRAN__
-    subroutine ints_ptr_assign(lhs, rhs)
-      type(ints_type), pointer, intent(out) :: lhs
-      type(ints_type), target, intent(in) :: rhs
-      lhs => rhs
-    end subroutine
+  subroutine ints_ptr_assign(lhs, rhs)
+    type(ints_type), pointer, intent(out) :: lhs
+    type(ints_type), target, intent(in) :: rhs
+    lhs => rhs
+  end subroutine
 #endif
 
 end module ints_module

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -31,7 +31,7 @@ module ints_module
 
       hash = 0
       do i = 1, size(ints%ints)
-        hash = xor(hash, ints%ints(i) + 1640531527 + ishft(hash, 6) + ishft(hash, -2))
+        hash = ieor(hash, ints%ints(i) + 1640531527 + ishft(hash, 6) + ishft(hash, -2))
       enddo
     end function
 

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -19,7 +19,10 @@ contains
     integer(kind(ints%ints)) :: hash
 
     real(real64), parameter :: phi = (sqrt(5.0_real64) + 1) / 2
-    integer, parameter :: magic_number = nint(2.0_real64**bit_size(hash) * (1 - 1 / phi)) ! = 1640531527 for 32 bit
+    ! Do not use `nint` intrinsic, because ifort claims that  "Fortran 2018 specifies that
+    ! "an elemental intrinsic function here be of type integer or character and
+    !  each argument must be an initialization expr of type integer or character":
+    integer, parameter :: magic_number = 0.5d0 + 2.0d0**bit_size(hash) * (1 - 1 / phi)
     integer :: i
 
     hash = 0

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -1,6 +1,6 @@
+#define SHORTNAME i2char
 #define KEY_TYPE integer
 #define VALUE_TYPE character(10)
-#define SHORTNAME i2char
 #include "fhash.f90"
 
 ! Define the module for the key type.
@@ -61,6 +61,7 @@ contains
 end module ints_module
 
 ! Define the macros needed by fhash and include fhash.f90
+#define SHORTNAME ints_double
 #define KEY_USE use ints_module
 #define KEY_TYPE type(ints_type)
 #define KEYS_EQUAL_FUNC ints_equal
@@ -68,15 +69,14 @@ end module ints_module
 #define VALUE_TYPE real(real64)
 #define HASH_FUNC hash_value
 #define VALUE_TYPE_INIT 0.0
-#define SHORTNAME ints_double
 #include "fhash.f90"
 
 ! Define the macros needed by fhash and include fhash.f90
+#define SHORTNAME int_ints_ptr
 #define KEY_TYPE integer
 #define VALUE_USE use ints_module
 #define VALUE_TYPE type(ints_type), pointer
 !#define VALUE_TYPE_INIT null()
-#define SHORTNAME int_ints_ptr
 #define VALUE_POINTER
 #ifdef VALUE_TYPE_INIT
 #define CHECK_ITERATOR_VALUE

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -25,10 +25,8 @@ module ints_module
       type(ints_type), intent(in) :: ints
       integer(kind(ints%ints)) :: hash
 
-      ! Assume either 32 or 64 bits:
-      integer, parameter :: bits = merge(64, 32, kind(ints%ints) == int64)
       real(real64), parameter :: phi = (sqrt(5.0_real64) + 1) / 2
-      integer, parameter :: magic_number = nint(2.0_real64**bits * (1 - 1 / phi)) ! = 1640531527 for 32 bit
+      integer, parameter :: magic_number = nint(2.0_real64**bit_size(hash) * (1 - 1 / phi)) ! = 1640531527 for 32 bit
       integer :: i
 
       hash = 0

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -74,6 +74,7 @@ end module ints_module
 #define KEYS_EQUAL_FUNC ints_equal
 #define VALUE_USE use, intrinsic :: iso_fortran_env
 #define VALUE_TYPE real(real64)
+#define HASH_FUNC hash_value
 #define VALUE_TYPE_INIT 0.0
 #define SHORTNAME ints_double
 #include "fhash.f90"
@@ -101,6 +102,7 @@ end module
 #define VALUE_USE use ints_module
 #define VALUE_TYPE type(ints_type), pointer
 !#define VALUE_TYPE_INIT null()
+#define HASH_FUNC hash_value
 #define SHORTNAME int_ints_ptr
 #ifndef __GFORTRAN__
 #define VALUE_POINTER

--- a/fhash_modules.f90
+++ b/fhash_modules.f90
@@ -1,3 +1,8 @@
+#define KEY_TYPE integer
+#define VALUE_TYPE character(10)
+#define SHORTNAME i2char
+#include "fhash.f90"
+
 ! Define the module for the key type.
 module ints_module
 

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -8,7 +8,6 @@ program fhash_test
   implicit none
 
   real :: start, finish
-  integer :: numKeys
 
   call test_contructor()
   call test_reserve()
@@ -20,15 +19,8 @@ program fhash_test
   print *, 'ALL TESTS PASSED.'
   print *, 'Start benchmark:'
 
-  ! Benchmark
-  numKeys = 10000000
-#ifdef __GFORTRAN__
-  if (__SIZEOF_POINTER__ == 8) numKeys = numKeys * 2
-#else
-  if (int_ptr_kind() == 8) numKeys = numKeys * 2
-#endif
   call cpu_time(start)
-  call benchmark(2, numKeys)
+  call benchmark(n_ints=2, n_keys=10000000)
   call cpu_time(finish)
   print '("Time finish = ", G0.3," seconds.")', finish - start
 

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -41,14 +41,13 @@ contains
       call assert(val == kv_list(i)%value, "bad value in sorted list")
     enddo
     call assert(kv_list(2:)%key - kv_list(:size(kv_list)-1)%key > 0, "sorted list should be strictly increasing")
-
-  contains
-    integer function compare_ints(a, b)
-      integer, intent(in) :: a, b
-
-      compare_ints = a - b
-    end function
   end subroutine
+
+  integer function compare_ints(a, b)
+    integer, intent(in) :: a, b
+
+    compare_ints = a - b
+  end function
 
   subroutine test_deep_storage_size()
     type(fhash_type__ints_double) :: h

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -15,10 +15,13 @@ contains
     logical :: success
 
     call h%reserve(3)
+    call h%set(1, "one (typo)")
     call h%set(1, "one       ")
     call h%set(0, "zero      ")
     call h%set(4, "four      ")
     call h%set(7, "seven     ")
+
+    call assert(h%get_ptr(1) == "one", 'expected  h%get_ptr(1) == "one"')
     
     call h%as_list(kv_list)
     call assert(allocated(kv_list), "kv_list not allocated")
@@ -28,6 +31,23 @@ contains
       call assert(success, "key in list was not in hash")
       call assert(val == kv_list(i)%value, "bad value in list")
     enddo
+
+    call h%as_sorted_list(kv_list, compare_ints)
+    call assert(allocated(kv_list), "sorted kv_list not allocated")
+    call assert(size(kv_list) == 4, "sorted kv_list has bad size")
+    do i = 1, size(kv_list)
+      call h%get(kv_list(i)%key, val, success)
+      call assert(success, "key in sorted list was not in hash")
+      call assert(val == kv_list(i)%value, "bad value in sorted list")
+    enddo
+    call assert(kv_list(2:)%key - kv_list(:size(kv_list)-1)%key > 0, "sorted list should be strictly increasing")
+
+  contains
+    integer function compare_ints(a, b)
+      integer, intent(in) :: a, b
+
+      compare_ints = a - b
+    end function
   end subroutine
 
   subroutine test_deep_storage_size()

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -9,9 +9,10 @@ contains
     use i2char_mod
 
     type(i2char_t) :: h
-    type(i2char_kv_t), allocatable :: kv_list(:)
     character(10) :: val
     integer :: i
+    integer, parameter :: n_uniq = 4
+    type(i2char_kv_t) :: kv_list(n_uniq)
     logical :: success
 
     call h%reserve(3)
@@ -20,22 +21,19 @@ contains
     call h%set(0, "zero      ")
     call h%set(4, "four      ")
     call h%set(7, "seven     ")
-
     call assert(h%get_ptr(1) == "one", 'expected  h%get_ptr(1) == "one"')
     
     call h%as_list(kv_list)
-    call assert(allocated(kv_list), "kv_list not allocated")
-    call assert(size(kv_list) == 4, "kv_list has bad size")
-    do i = 1, size(kv_list)
+    call assert(size(kv_list) == n_uniq, "kv_list has bad size")
+    do i = 1, n_uniq
       call h%get(kv_list(i)%key, val, success)
       call assert(success, "key in list was not in hash")
       call assert(val == kv_list(i)%value, "bad value in list")
     enddo
 
     call h%as_sorted_list(kv_list, compare_ints)
-    call assert(allocated(kv_list), "sorted kv_list not allocated")
-    call assert(size(kv_list) == 4, "sorted kv_list has bad size")
-    do i = 1, size(kv_list)
+    call assert(size(kv_list) == n_uniq, "sorted kv_list has bad size")
+    do i = 1, n_uniq
       call h%get(kv_list(i)%key, val, success)
       call assert(success, "key in sorted list was not in hash")
       call assert(val == kv_list(i)%value, "bad value in sorted list")
@@ -75,6 +73,7 @@ contains
       call assert(h%key_count() == 2, 'expected two keys in h')
     enddo
 
+    allocate(kv_list(h%key_count()))
     call h%as_sorted_list(kv_list, compare_ints)
     call assert(size(kv_list) == 2, "expected size(kv_list) == 2")
     call assert(kv_list%key == [2, 7], "keys should be [2, 7]")

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -5,6 +5,31 @@ module tests_mod
   implicit none
 
 contains
+  subroutine test_as_list
+    use fhash_module__i2char
+
+    type(fhash_type__i2char) :: h
+    type(fhash_type_kv__i2char), allocatable :: kv_list(:)
+    character(10) :: val
+    integer :: i
+    logical :: success
+
+    call h%reserve(3)
+    call h%set(1, "one       ")
+    call h%set(0, "zero      ")
+    call h%set(4, "four      ")
+    call h%set(7, "seven     ")
+    
+    call h%as_list(kv_list)
+    call assert(allocated(kv_list), "kv_list not allocated")
+    call assert(size(kv_list) == 4, "kv_list has bad size")
+    do i = 1, size(kv_list)
+      call h%get(kv_list(i)%key, val, success)
+      call assert(success, "key in list was not in hash")
+      call assert(val == kv_list(i)%value, "bad value in list")
+    enddo
+  end subroutine
+
   subroutine test_deep_storage_size()
     type(fhash_type__ints_double) :: h
     type(ints_type) :: key
@@ -119,6 +144,7 @@ program fhash_test
   call test_insert_and_get_int_ints_ptr()
   call test_insert_get_and_remove_int_ints_ptr()
   call test_iterate()
+  call test_as_list()
   call test_deep_storage_size()
   call test_assignment()
 

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -311,7 +311,8 @@ program fhash_test
   subroutine test_insert_get_and_remove_int_ints_ptr()
     type(int_ints_ptr_t) :: h
     integer, parameter ::  num_values = 50
-    type(ints_type), pointer :: pValues(:), pValue
+    type(ints_type), pointer :: pValue
+    type(ints_type), target, allocatable :: pValues(:)
     logical :: success
     integer ::  i, key, status
     type(int_ints_ptr_iter_t) :: it
@@ -324,9 +325,9 @@ program fhash_test
     
     ! add
     do i = 1, num_values
+      allocate(pValues(i)%ints(2))
+      pValues(i)%ints(1) = i
       pValue => pValues(i)
-      allocate(pValue%ints(2))
-      pValue%ints(1) = i
       call h%set(i, pValue)
     end do
     
@@ -334,7 +335,6 @@ program fhash_test
 
     ! get
     do i = num_values, i, -1
-      nullify(pValue)
       call h%get(i, pValue, success)
       if (.not. success) stop 'expect a value for given key '
       if (pValue%ints(1) .ne. pValues(i)%ints(1)) stop 'expect different value for given key'
@@ -384,8 +384,6 @@ program fhash_test
 #endif
 
     call h%clear()
-    
-    deallocate(pValues)
   end subroutine  
   
   subroutine test_iterate()

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -43,6 +43,44 @@ contains
     call assert(kv_list(2:)%key - kv_list(:size(kv_list)-1)%key > 0, "sorted list should be strictly increasing")
   end subroutine
 
+  subroutine test_get_ptr()
+    use i2char_mod
+
+    type(i2char_t) :: h
+    character(:), pointer :: c
+    type(i2char_kv_t), allocatable :: kv_list(:)
+    integer :: i
+
+    call h%reserve(1)
+    
+    call h%set(7, "seven     ")
+
+    c => h%get_ptr(0)
+    call assert(.not. associated(c), "expected .not. associated(c)")
+    c => h%get_ptr(1)
+    call assert(.not. associated(c), "expected .not. associated(c)")
+    c => h%get_ptr(7)
+    call assert(associated(c), "expected associated(c)")
+    call assert(c == "seven", "exptected c == 'seven'")
+    
+    c(:) = 'new seven'
+    c => h%get_ptr(7)
+    call assert(associated(c), "expected associated(c)")
+    call assert(c == 'new seven', "expected c == 'new seven'")
+
+    do i = 1, 3
+      c => h%get_ptr(2, autoval='auto two  ')
+      call assert(associated(c), "expected associated(c)")
+      call assert(c == 'auto two', "expected c == 'auto two'")
+      call assert(h%key_count() == 2, 'expected two keys in h')
+    enddo
+
+    call h%as_sorted_list(kv_list, compare_ints)
+    call assert(size(kv_list) == 2, "expected size(kv_list) == 2")
+    call assert(kv_list%key == [2, 7], "keys should be [2, 7]")
+    call assert(kv_list%value == ['auto two ', 'new seven'], "test_get_ptr: bad values")
+  end subroutine
+
   integer function compare_ints(a, b)
     integer, intent(in) :: a, b
 
@@ -157,6 +195,7 @@ program fhash_test
   use tests_mod
   implicit none
 
+  call test_get_ptr()
   call test_contructor()
   call test_reserve()
   call test_insert_and_get_ints_double()

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -5,6 +5,31 @@ module tests_mod
   implicit none
 
 contains
+  subroutine test_deep_storage_size()
+    type(fhash_type__ints_double) :: h
+    type(ints_type) :: key
+    
+    integer :: i
+    integer :: s
+
+    s = h%deep_storage_size(0123)
+    
+    call h%reserve(10)
+    allocate(key%ints(2))
+    
+    do i = 1, 3
+      key%ints = i
+      call h%set(key, real(i, kind=real64))
+    enddo
+    s = h%deep_storage_size(0123)
+    
+    do i = 1, 20
+      key%ints = i
+      call h%set(key, real(i, kind=real64))
+    enddo
+    s = h%deep_storage_size(0123)
+  end subroutine
+
   subroutine test_assignment()
     type(fhash_type__ints_double) :: a, b, c
     type(ints_type) :: keys(100)
@@ -94,6 +119,7 @@ program fhash_test
   call test_insert_and_get_int_ints_ptr()
   call test_insert_get_and_remove_int_ints_ptr()
   call test_iterate()
+  call test_deep_storage_size()
   call test_assignment()
 
   print *, 'ALL TESTS PASSED.'

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -7,8 +7,6 @@ program fhash_test
 
   implicit none
 
-  real :: start, finish
-
   call test_contructor()
   call test_reserve()
   call test_insert_and_get_ints_double()
@@ -17,13 +15,6 @@ program fhash_test
   call test_iterate()
 
   print *, 'ALL TESTS PASSED.'
-  print *, 'Start benchmark:'
-
-  call cpu_time(start)
-  call benchmark(n_ints=2, n_keys=10000000)
-  call cpu_time(finish)
-  print '("Time finish = ", G0.3," seconds.")', finish - start
-
   contains
 
   subroutine test_contructor()
@@ -209,28 +200,4 @@ program fhash_test
     
     call h%clear()
   end subroutine
-
-  subroutine benchmark(n_ints, n_keys)
-    integer, intent(in) :: n_ints, n_keys
-    type(fhash_type__ints_double) :: h
-    type(ints_type) :: key
-    real :: start, finish
-    integer :: i, j
-
-    print '("n_ints: ", I0, ", n_keys: ", I0)', n_ints, n_keys
-
-    call cpu_time(start)
-    call h%reserve(n_keys * 2)
-    allocate(key%ints(n_ints))
-    do i = 1, n_keys
-      do j = 1, n_ints
-        key%ints(j) = i + j
-      enddo
-      call h%set(key, (i + j) * 0.5_real64)
-    enddo
-    call cpu_time(finish)
-    print '("Time insert = ", G0.3," seconds.")', finish - start
-    call h%clear()
-  end subroutine
-
 end program

--- a/fhash_test.f90
+++ b/fhash_test.f90
@@ -1,15 +1,15 @@
 module tests_mod
   use ints_module
-  use fhash_module__ints_double
+  use ints_double_mod
   use, intrinsic :: iso_fortran_env
   implicit none
 
 contains
   subroutine test_as_list
-    use fhash_module__i2char
+    use i2char_mod
 
-    type(fhash_type__i2char) :: h
-    type(fhash_type_kv__i2char), allocatable :: kv_list(:)
+    type(i2char_t) :: h
+    type(i2char_kv_t), allocatable :: kv_list(:)
     character(10) :: val
     integer :: i
     logical :: success
@@ -50,7 +50,7 @@ contains
   end function
 
   subroutine test_deep_storage_size()
-    type(fhash_type__ints_double) :: h
+    type(ints_double_t) :: h
     type(ints_type) :: key
     
     integer :: i
@@ -75,7 +75,7 @@ contains
   end subroutine
 
   subroutine test_assignment()
-    type(fhash_type__ints_double) :: a, b, c
+    type(ints_double_t) :: a, b, c
     type(ints_type) :: keys(100)
     real(real64) :: values(size(keys))
 
@@ -111,9 +111,9 @@ contains
     call check_kv(b)
   contains
       subroutine check_kv(fhash)
-        type(fhash_type__ints_double), intent(in) :: fhash
+        type(ints_double_t), intent(in) :: fhash
 
-        type(fhash_type_iterator__ints_double) :: iter
+        type(ints_double_iter_t) :: iter
         type(ints_type) :: key
         real(real64) :: val
         integer :: i
@@ -151,8 +151,8 @@ end module
 program fhash_test
 
   use, intrinsic :: iso_fortran_env
-  use fhash_module__ints_double
-  use fhash_module__int_ints_ptr
+  use ints_double_mod
+  use int_ints_ptr_mod
   use ints_module
   use tests_mod
   implicit none
@@ -171,19 +171,19 @@ program fhash_test
   contains
 
   subroutine test_contructor()
-    type(fhash_type__ints_double) h
+    type(ints_double_t) h
     if (h%key_count() /= 0) stop 'expect no keys'
   end subroutine
 
   subroutine test_reserve()
-    type(fhash_type__ints_double) :: h
+    type(ints_double_t) :: h
 
     call h%reserve(3)
     call assert(h%bucket_count() == 5, 'expected to reserve 5 buckets')
   end subroutine
 
   subroutine test_insert_and_get_ints_double()
-    type(fhash_type__ints_double) :: h
+    type(ints_double_t) :: h
     type(ints_type) :: key
     real(real64) :: value
     real(real64), pointer :: val_ptr
@@ -219,7 +219,7 @@ program fhash_test
   end subroutine
 
   subroutine test_insert_and_get_int_ints_ptr()
-    type(fhash_type__int_ints_ptr) :: h
+    type(int_ints_ptr_t) :: h
     type(ints_type), target :: value
     type(ints_type), pointer :: value_ptr, value_ptr2, value_ptr3
     logical :: success
@@ -237,12 +237,12 @@ program fhash_test
   end subroutine
 
   subroutine test_insert_get_and_remove_int_ints_ptr()
-    type(fhash_type__int_ints_ptr) :: h
+    type(int_ints_ptr_t) :: h
     integer, parameter ::  num_values = 50
     type(ints_type), pointer :: pValues(:), pValue
     logical :: success
     integer ::  i, key, status
-    type(fhash_type_iterator__int_ints_ptr) :: it
+    type(int_ints_ptr_iter_t) :: it
     
     ! prepare
     allocate(pValues(num_values))
@@ -317,8 +317,8 @@ program fhash_test
   end subroutine  
   
   subroutine test_iterate()
-    type(fhash_type__ints_double) :: h
-    type(fhash_type_iterator__ints_double) :: it
+    type(ints_double_t) :: h
+    type(ints_double_iter_t) :: it
     type(ints_type) :: key
     real(real64) :: value
     integer :: i, j


### PR DESCRIPTION
Hi Junhao Li,

Thanks a lot for contributing this code! I can tell you it will be used to model traffic flow in the Netherlands.

I did find some places in which the code could be cleaned up a bit, and collected them in this branch. I hope it will be of use to you and others as well.

The main things it addresses:

1. corrected `intent` statements (inout --> in)

1. corrected `.not. associated(this%node_ptr) .or. .not. allocated(this%node_ptr%kv)` statement (Fortran is not guaranteed to evaluate from left to right)

1. deleted redundant `deallocate` statements

1. simplified `node_get`

1. greatly simplified the `clean` procedures. Furthermore, memory is now freed automatically by destructors (aka finalizers), so the user does not need to call `clean` on the hash table.

1. `non_overridable` procedures (also helps the compiler to know what exact method you're calling at compile time)

1. Some more flags in the Makefile (maybe you don't want those)