### PR TITLE
Update fhash.f90

### DIFF
--- a/fhash.f90
+++ b/fhash.f90
@@ -392,7 +392,12 @@ module FHASH_MODULE_NAME
     VALUE_TYPE, intent(out) :: value
     integer, optional, intent(out) :: status
 
-    do while (.not. associated(this%node_ptr) .or. .not. allocated(this%node_ptr%kv))
+    do
+    
+      IF(ASSOCIATED(this%node_ptr)) THEN
+        IF(ALLOCATED(this%node_ptr%kv) ) EXIT
+      END IF
+      
       if (this%bucket_id < this%fhash_ptr%n_buckets) then
         this%bucket_id = this%bucket_id + 1
         this%node_ptr => this%fhash_ptr%buckets(this%bucket_id)


### PR DESCRIPTION
Updating next method 

The following line:

```fortran
do while (.not. associated(this%node_ptr) .or. .not. allocated(this%node_ptr%kv))
```
will cause problem. 

When `this%node_ptr` not associated, and we access `this%node_ptr%kv`. it will cause segmentation fault. 

Usually compiler does not have short circuit check like phthon and other language.

So I have modified this line. 

```fortran
    DO
      IF(ASSOCIATED(this%node_ptr)) THEN
        IF(ALLOCATED(this%node_ptr%kv) ) EXIT
      END IF
```